### PR TITLE
fix(scripts): support spaces in the $HOME env variable

### DIFF
--- a/scripts/remote-install-update-mathlib.sh
+++ b/scripts/remote-install-update-mathlib.sh
@@ -65,26 +65,25 @@ curl -o post-commit https://raw.githubusercontent.com/leanprover-community/mathl
 curl -o post-checkout https://raw.githubusercontent.com/leanprover-community/mathlib-tools/$BRANCH/scripts/post-checkout
 echo "installing it in \$HOME/.mathlib/bin"
 chmod +x update-mathlib.py
-mkdir -p $HOME/.mathlib/bin || true
-mkdir -p $HOME/.mathlib/hooks || true
+mkdir -p "$HOME"/.mathlib/bin || true
+mkdir -p "$HOME"/.mathlib/hooks || true
 
-mv update-mathlib.py       $HOME/.mathlib/bin/update-mathlib
-mv cache-olean.py          $HOME/.mathlib/bin/cache-olean
-mv delayed_interrupt.py    $HOME/.mathlib/bin/
-mv auth_github.py          $HOME/.mathlib/bin/
-mv setup-lean-git-hooks.sh $HOME/.mathlib/bin/setup-lean-git-hooks
-mv post-commit   $HOME/.mathlib/hooks/
-mv post-checkout $HOME/.mathlib/hooks/
+mv update-mathlib.py       "$HOME"/.mathlib/bin/update-mathlib
+mv cache-olean.py          "$HOME"/.mathlib/bin/cache-olean
+mv delayed_interrupt.py    "$HOME"/.mathlib/bin/
+mv auth_github.py          "$HOME"/.mathlib/bin/
+mv setup-lean-git-hooks.sh "$HOME"/.mathlib/bin/setup-lean-git-hooks
+mv post-commit   "$HOME"/.mathlib/hooks/
+mv post-checkout "$HOME"/.mathlib/hooks/
 
-if grep -q ".mathlib/bin" $HOME/.profile
+if grep -q ".mathlib/bin" "$HOME"/.profile
 then
     echo mathlib scripts are already added to \$PATH in .profile
 else
     echo "Adding a path modification in .profile"
-    touch $HOME/.profile
-    echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> $HOME/.profile
-    echo $HOME/.profile
-    ls $HOME/.profile
-    echo "You should now run \"source $HOME/.profile\""
+    touch "$HOME"/.profile
+    echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> "$HOME"/.profile
+    echo "$HOME"/.profile
+    ls "$HOME"/.profile
+    echo "You should now run 'source \"$HOME\"/.profile'"
 fi
-

--- a/scripts/setup-dev-scripts.sh
+++ b/scripts/setup-dev-scripts.sh
@@ -49,8 +49,8 @@ for dep in $PYTHON_DEPS ; do
 	fi
 done
 
-touch $HOME/.profile
-X=$(grep -q ".mathlib/bin" $HOME/.profile)
+touch "$HOME"/.profile
+X=$(grep -q ".mathlib/bin" "$HOME"/.profile)
 SCRIPTS_ON_PATH=$?
 
 echo "This script will:"
@@ -78,25 +78,25 @@ then
 	# TODO we could test the status of all these files, and skip this step if everything is already up to date?
 	BASEDIR=$(dirname "$0")
 	cd $BASEDIR
-	mkdir -p $HOME/.mathlib/bin || true
-	mkdir -p $HOME/.mathlib/hooks || true
-	cp auth_github.py          $HOME/.mathlib/bin/
-	cp delayed_interrupt.py    $HOME/.mathlib/bin/
-	cp update-mathlib.py       $HOME/.mathlib/bin/update-mathlib
-	cp cache-olean.py          $HOME/.mathlib/bin/cache-olean
-	cp setup-lean-git-hooks.sh $HOME/.mathlib/bin/setup-lean-git-hooks
-        chmod +x $HOME/.mathlib/bin/update-mathlib
-        chmod +x $HOME/.mathlib/bin/cache-olean
-        chmod +x $HOME/.mathlib/bin/setup-lean-git-hooks
-	cp post-commit   $HOME/.mathlib/hooks/
-	cp post-checkout $HOME/.mathlib/hooks/
+	mkdir -p "$HOME"/.mathlib/bin || true
+	mkdir -p "$HOME"/.mathlib/hooks || true
+	cp auth_github.py          "$HOME"/.mathlib/bin/
+	cp delayed_interrupt.py    "$HOME"/.mathlib/bin/
+	cp update-mathlib.py       "$HOME"/.mathlib/bin/update-mathlib
+	cp cache-olean.py          "$HOME"/.mathlib/bin/cache-olean
+	cp setup-lean-git-hooks.sh "$HOME"/.mathlib/bin/setup-lean-git-hooks
+        chmod +x "$HOME"/.mathlib/bin/update-mathlib
+        chmod +x "$HOME"/.mathlib/bin/cache-olean
+        chmod +x "$HOME"/.mathlib/bin/setup-lean-git-hooks
+	cp post-commit   "$HOME"/.mathlib/hooks/
+	cp post-checkout "$HOME"/.mathlib/hooks/
 	if [[ $SCRIPTS_ON_PATH -eq 0 ]]
 	then
 	    echo ... mathlib scripts are already added to \$PATH in .profile
 	else
 	    echo ... adding "export PATH=\"\$HOME/.mathlib/bin:\$PATH\"" in \$HOME/.profile
-	    echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> $HOME/.profile
-	    echo ... now run: \"source \$HOME/.profile\"
+	    echo "export PATH=\"\$HOME/.mathlib/bin:\$PATH\" " >> "$HOME"/.profile
+	    echo ... now run: \'source \"$HOME\"/.profile\'
 	fi
 	echo "... finished setting up development scripts."
 else

--- a/scripts/setup-lean-git-hooks.sh
+++ b/scripts/setup-lean-git-hooks.sh
@@ -6,8 +6,8 @@ if [ -e $HOOK_DIR ]; then
 	echo    # (optional) move to a new line
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
-	    cp $HOME/.mathlib/hooks/post-commit $HOOK_DIR &&
-	    cp $HOME/.mathlib/hooks/post-checkout $HOOK_DIR &&
+	    cp "$HOME"/.mathlib/hooks/post-commit $HOOK_DIR &&
+	    cp "$HOME"/.mathlib/hooks/post-checkout $HOOK_DIR &&
 	    echo "Successfully copied scripts"
 	else
 		echo "Cancelled..."


### PR DESCRIPTION
This PR fixes installation issues when the user name contains spaces, e.g. in Windows or OS X.

The problem is easily fixed by enclosing all the occurrences of the `$HOME` environment variable with double quotes ("). I also changed the messages asking to reload `"$HOME"/.profile` to avoid the same issue when the user types the same command on terminal.