### PR TITLE
more permissive check for mathlib dependencies

### DIFF
--- a/scripts/update-mathlib.py
+++ b/scripts/update-mathlib.py
@@ -49,6 +49,9 @@ else:
               'instead of a GitHub repository')
         sys.exit(1)
 
+    # some leanpkg files might contain urls ending in '/'
+    git_url = git_url.rstrip('/')
+    
     if git_url not in ['https://github.com/leanprover/mathlib',
                        'https://github.com/leanprover-community/mathlib']:
         print('Error: mathlib reference is a fork')


### PR DESCRIPTION
I'm updating an old project with the dependency "https://github.com/leanprover-community/mathlib/". Took me a minute to figure out why `update-mathlib` was failing.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
