### PR TITLE
feat(default.nix): add build file for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This package contains several supporting tools for [Lean mathlib](https://leanprover-community.github.io/).
 
   - `update-mathlib` fetches precompiled olean files if you use mathlib as a dependency
-  - `cache-olean` fetches precompiled olean files if you're working on mathlib
+  - `cache-olean` caches olean files, and if you're working on mathlib it can also fetch precompiled olean files from github
   - `setup-lean-git-hooks` automates the usage of `cache-olean` using git hooks
 
 See also [the documentation in the mathlib repository](https://github.com/leanprover-community/mathlib/blob/8700aa7d78b10b65cf8db1d9e320872ae313517a/docs/contribute/index.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # mathlib-tools
 
-Supporting tools for [Lean mathlib](https://leanprover-community.github.io/).
-
 [![Build Status](https://travis-ci.org/leanprover-community/mathlib-tools.svg?branch=master)](https://travis-ci.org/leanprover-community/mathlib-tools)
 [![Build status](https://ci.appveyor.com/api/projects/status/t353pkb62tep1rth?svg=true)](https://ci.appveyor.com/project/cipher1024/mathlib-tools)
+
+This package contains several supporting tools for [Lean mathlib](https://leanprover-community.github.io/).
+
+  - `update-mathlib` fetches precompiled olean files if you use mathlib as a dependency
+  - `cache-olean` fetches precompiled olean files if you're working on mathlib
+  - `setup-lean-git-hooks` automates the usage of `cache-olean` using git hooks
+
+See also [the documentation in the mathlib repository](https://github.com/leanprover-community/mathlib/blob/8700aa7d78b10b65cf8db1d9e320872ae313517a/docs/contribute/index.md).
+
+You can install `mathlib-tools` using [pip](https://pypi.org/project/mathlibtools/):
+```
+sudo pip3 install mathlibtools
+```
+
+If you are using NixOS, you can also install it using the bundled `default.nix` file:
+```
+nix-env -if https://github.com/leanprover-community/mathlib-tools/archive/master.tar.gz
+```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs.python3Packages;
+buildPythonApplication {
+  pname = "mathlib-tools";
+  version = "0.0.2";
+  src = ./.;
+
+  propagatedBuildInputs = [
+    PyGithub GitPython toml
+  ];
+}


### PR DESCRIPTION
This makes it possible to easily install `mathlib-tools` on NixOS.  I've also expanded the readme file a bit.