### PR TITLE
check Azure for archives before checking nightlies

### DIFF
--- a/bin/cache-olean
+++ b/bin/cache-olean
@@ -7,7 +7,7 @@ import signal
 from git import Repo, InvalidGitRepositoryError
 
 from mathlibtools.delayed_interrupt import DelayedInterrupt
-from mathlibtools.fetching import mathlib_asset_from_azure, fetch_mathlib
+from mathlibtools.fetching import mathlib_asset_from_azure_or_nightly, fetch_mathlib
 
 
 def make_cache(fn):
@@ -64,7 +64,7 @@ if __name__ == "__main__":
             ar.close()
             print('... successfully fetched local cache.')
         else:
-            asset_name, asset_url = mathlib_asset_from_azure(rev)
+            asset_name, asset_url = mathlib_asset_from_azure_or_nightly(rev)
             if asset_name:
                 fetch_mathlib(asset_name, asset_url)
             else:

--- a/bin/cache-olean
+++ b/bin/cache-olean
@@ -7,7 +7,7 @@ import signal
 from git import Repo, InvalidGitRepositoryError
 
 from mathlibtools.delayed_interrupt import DelayedInterrupt
-from mathlibtools.fetching import mathlib_asset, fetch_mathlib
+from mathlibtools.fetching import mathlib_asset_from_azure, fetch_mathlib
 
 
 def make_cache(fn):
@@ -64,9 +64,9 @@ if __name__ == "__main__":
             ar.close()
             print('... successfully fetched local cache.')
         else:
-            asset = mathlib_asset(rev)
-            if asset:
-                fetch_mathlib(asset)
+            asset_name, asset_url = mathlib_asset_from_azure(rev)
+            if asset_name:
+                fetch_mathlib(asset_name, asset_url)
             else:
                 print('no cache found')
     elif sys.argv[1:] == ['--build']:

--- a/bin/update-mathlib
+++ b/bin/update-mathlib
@@ -4,48 +4,57 @@ import os.path
 import os
 import sys
 import toml
+import argparse
 
-from mathlibtools.fetching import mathlib_asset, fetch_mathlib
+from mathlibtools.fetching import mathlib_asset_from_azure, mathlib_asset_from_url, fetch_mathlib
 
-# find root of project and leanpkg.toml
-cwd = os.getcwd()
-while not os.path.isfile('leanpkg.toml') and os.getcwd() != '/':
-    os.chdir(os.path.dirname(os.getcwd()))
+def get_rev_from_toml():
+    # find root of project and leanpkg.toml
+    while not os.path.isfile('leanpkg.toml') and os.getcwd() != '/':
+        os.chdir(os.path.dirname(os.getcwd()))
 
-# parse leanpkg.toml
-try:
-    leanpkg = toml.load('leanpkg.toml')
-except FileNotFoundError:
-    print('Error: No leanpkg.toml found')
-    sys.exit(1)
+    # parse leanpkg.toml
+    try:
+        leanpkg = toml.load('leanpkg.toml')
+    except FileNotFoundError:
+        print('Error: No leanpkg.toml found')
+        sys.exit(1)
 
-try:
-    lib = leanpkg['dependencies']['mathlib']
-except KeyError:
-    print('Error: Project does not depend on mathlib')
-    sys.exit(1)
+    try:
+        lib = leanpkg['dependencies']['mathlib']
+    except KeyError:
+        print('Error: Project does not depend on mathlib')
+        sys.exit(1)
 
-try:
-    git_url = lib['git']
-    rev = lib['rev']
-except KeyError:
-    print('Error: Project seems to refer to a local copy of mathlib '
-          'instead of a GitHub repository')
-    sys.exit(1)
+    try:
+    #    git_url = lib['git']
+        rev = lib['rev']
+    except KeyError:
+        print('Error: Project seems to refer to a local copy of mathlib '
+            'instead of a GitHub repository')
+        sys.exit(1)
+    return rev
 
-# some leanpkg files might contain urls ending in '/'
-git_url = git_url.rstrip('/')
+# it shouldn't matter anymore where the mathlib is coming from
+## some leanpkg files might contain urls ending in '/'
+# git_url = git_url.rstrip('/')
+#
+# if git_url not in ['https://github.com/leanprover/mathlib',
+#                    'git@github.com:leanprover/mathlib.git',
+#                    'https://github.com/leanprover-community/mathlib',
+#                    'git@github.com:leanprover-community/mathlib.git']:
+#     print('Error: mathlib reference', git_url, 'seems to be a fork')
+#     sys.exit(1)
 
-if git_url not in ['https://github.com/leanprover/mathlib',
-                   'git@github.com:leanprover/mathlib.git',
-                   'https://github.com/leanprover-community/mathlib',
-                   'git@github.com:leanprover-community/mathlib.git']:
-    print('Error: mathlib reference', git_url, 'seems to be a fork')
-    sys.exit(1)
+parser = argparse.ArgumentParser(description='Fetch .olean files for a mathlib dependency.')
+parser.add_argument('--from-url', dest='url', default=None,
+                    help='a url to a tar.gz archive containing olean files (default from mathlib server)')
+args = parser.parse_args()
 
-asset = mathlib_asset(rev)
+asset_name, asset_url = mathlib_asset_from_url(args.url) if args.url else mathlib_asset_from_azure(get_rev_from_toml())
+
 # Get archive if needed
-if asset:
-    fetch_mathlib(asset, target='_target/deps/mathlib')
+if asset_name:
+    fetch_mathlib(asset_name, asset_url, target='_target/deps/mathlib')
 else:
     print('no cache found')

--- a/bin/update-mathlib
+++ b/bin/update-mathlib
@@ -6,7 +6,7 @@ import sys
 import toml
 import argparse
 
-from mathlibtools.fetching import mathlib_asset_from_azure, mathlib_asset_from_url, fetch_mathlib
+from mathlibtools.fetching import mathlib_asset_from_azure_or_nightly, mathlib_asset_from_url, fetch_mathlib
 
 def get_rev_from_toml():
     # find root of project and leanpkg.toml
@@ -51,7 +51,7 @@ parser.add_argument('--from-url', dest='url', default=None,
                     help='a url to a tar.gz archive containing olean files (default from mathlib server)')
 args = parser.parse_args()
 
-asset_name, asset_url = mathlib_asset_from_url(args.url) if args.url else mathlib_asset_from_azure(get_rev_from_toml())
+asset_name, asset_url = mathlib_asset_from_url(args.url) if args.url else mathlib_asset_from_azure_or_nightly(get_rev_from_toml)
 
 # Get archive if needed
 if asset_name:

--- a/mathlibtools/fetching.py
+++ b/mathlibtools/fetching.py
@@ -8,7 +8,7 @@ import signal
 from mathlibtools.auth_github import auth_github
 from mathlibtools.delayed_interrupt import DelayedInterrupt
 
-def mathlib_asset(rev):
+def mathlib_asset_from_gh_nightly(rev):
     g = auth_github()
     print("Querying GitHub...")
     repo = g.get_repo("leanprover-community/mathlib-nightly")
@@ -19,7 +19,7 @@ def mathlib_asset(rev):
                            tags[r.tag_name] == rev)
     except StopIteration:
         print('Error: no nightly archive found')
-        return None
+        return None, None
 
     try:
         asset = next(x for x in release.get_assets()
@@ -27,31 +27,39 @@ def mathlib_asset(rev):
     except StopIteration:
         print("Error: Release " + release.tag_name + " does not contains a olean "
               "archive (this shouldn't happen...)")
-        return None
-    return asset
+        return None, None
+    return asset.name, asset.browser_download_url
 
+# rev: the full git hash of the desired mathlib commit
+def mathlib_asset_from_azure(rev):
+    name = '{}.tar.gz'.format(rev)
+    return name, 'https://oleanstorage.blob.core.windows.net/mathlib/' + name
 
-def fetch_mathlib(asset, target='.'):
+# url: a url pointing to a tar.gz file
+def mathlib_asset_from_url(url):
+    return url.split('/')[-1], url
+
+def fetch_mathlib(asset_name, asset_url, target='.'):
     mathlib_dir = os.path.join(os.environ['HOME'], '.mathlib')
     if not os.path.isdir(mathlib_dir):
         os.mkdir(mathlib_dir)
 
-    if not os.path.isfile(os.path.join(mathlib_dir, asset.name)):
+    if not os.path.isfile(os.path.join(mathlib_dir, asset_name)):
         print("Downloading nightly...")
         cd = os.getcwd()
         os.chdir(mathlib_dir)
         http = urllib3.PoolManager(
             cert_reqs='CERT_REQUIRED',
             ca_certs=certifi.where())
-        req = http.request('GET', asset.browser_download_url)
+        req = http.request('GET', asset_url)
         with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-            with open(asset.name, 'wb') as f:
+            with open(asset_name, 'wb') as f:
                 f.write(req.data)
         os.chdir(cd)
     else:
         print("Reusing cached olean archive")
 
     with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
-        ar = tarfile.open(os.path.join(mathlib_dir, asset.name))
-        ar.extractall(target)
+        ar = tarfile.open(os.path.join(mathlib_dir, asset_name))
+        ar.extractall(target, members=[m for m in ar.getmembers() if m.name.endswith('.olean')])
         print("... successfully extracted olean archive.")

--- a/mathlibtools/fetching.py
+++ b/mathlibtools/fetching.py
@@ -8,6 +8,11 @@ import signal
 from mathlibtools.auth_github import auth_github
 from mathlibtools.delayed_interrupt import DelayedInterrupt
 
+
+# this should check if a file exists at url without actually downloading it
+def archive_exists_at_url(url):
+    return False
+
 def mathlib_asset_from_gh_nightly(rev):
     g = auth_github()
     print("Querying GitHub...")
@@ -35,9 +40,16 @@ def mathlib_asset_from_azure(rev):
     name = '{}.tar.gz'.format(rev)
     return name, 'https://oleanstorage.blob.core.windows.net/mathlib/' + name
 
+# finds the asset at azure, if it exists, otherwise from the nightlies
+def mathlib_asset_from_azure_or_nightly(rev):
+    name, url = mathlib_asset_from_azure(rev)
+    if not archive_exists_at_url(url):
+        name, url = mathlib_asset_from_gh_nightly(rev)
+    return name, url
+
 # url: a url pointing to a tar.gz file
 def mathlib_asset_from_url(url):
-    return url.split('/')[-1], url
+    return url.split('/')[-1], url if archive_exists_at_url(url) else None, None
 
 def fetch_mathlib(asset_name, asset_url, target='.'):
     mathlib_dir = os.path.join(os.environ['HOME'], '.mathlib')


### PR DESCRIPTION
This also adds an optional flag to `update-mathlib`, `--from-url`, so the user can manually point it to an archive somewhere.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
