### PR TITLE
Don't bump GitPython version all that much

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent" ],
     python_requires='>=3.5',
-    install_requires=['toml', 'PyGithub', 'certifi', 'gitpython>=3.0.0', 'requests',
+    install_requires=['toml', 'PyGithub', 'certifi', 'gitpython>=2.1.11', 'requests',
                       'Click', 'tqdm', 'paramiko']
 )


### PR DESCRIPTION
2.1.11 is the oldest version containing https://github.com/gitpython-developers/GitPython/commit/7f08b7730438bde34ae55bc3793fa524047bb804, and coincidentally the version available in Nixpkgs stable.