### PR TITLE
Auth

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 with pkgs.python3Packages;
 buildPythonApplication {
   pname = "mathlib-tools";
-  version = "0.0.3";
+  version = "0.0.4";
   src = ./.;
 
   doCheck = false;

--- a/mathlibtools/auth_github.py
+++ b/mathlibtools/auth_github.py
@@ -2,13 +2,8 @@ from git import Repo, InvalidGitRepositoryError # type: ignore
 from github import Github # type: ignore
 import configparser
 
-def auth_github() -> Github:
-    try:
-        repo = Repo('.', search_parent_directories=True)
-        config = repo.config_reader()
-    except:
-        print('Warning: This does not seem to be a git repository. Expect weird things...')
-        return Github()
+def auth_github(repo: Repo) -> Github:
+    config = repo.config_reader()
     try:
         return Github(config.get('github', 'user'), config.get('github', 'password'))
     except configparser.NoSectionError:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mathlibtools",
-    version="0.0.3",
+    version="0.0.4",
     author="The mathlib community",
     description="Lean prover mathlib supporting tools.",
     long_description=long_description,


### PR DESCRIPTION
This restores trying to use Github authentication when accessing legacy olean caches. This should also get rid of the warning about not being in a Git repository.

I find it a bit annoying to open a PR for this because master is protected. Who has the power to change that?