### PR TITLE
Raise exceptions on leanpkg and git errors

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -163,8 +163,7 @@ def get_project(name: str, directory: str = '') -> None:
         name = name + '_' + branch
     directory = directory or name
     if directory and Path(directory).exists():
-        log.error(directory + ' already exists')
-        sys.exit(-1)
+        raise FileExistsError('Directory ' + directory + ' already exists')
     try:
         LeanProject.from_git_url(url, directory, branch,
                                  cache_url, force_download)

--- a/mathlibtools/post-commit
+++ b/mathlibtools/post-commit
@@ -9,6 +9,5 @@ if /usr/bin/env python3 -c ""; then
 	echo "Caching olean..."
 	leanproject mk-cache
 else
-    echo "'env python3' failed; not running post-checkout hook"
+    echo "'env python3' failed; not running post-commit hook"
 fi
-


### PR DESCRIPTION
When running `leanproject` in CI (and arguably in general), we want it to exit with a non-zero code if the command fails. Here, I make calls to `subprocess.run` raise an exception if the tool fails where that makes sense, so that the exception handler is called and `leanproject` overall exits with an error. Otherwise, builds that clearly failed ([e.g. here](https://github.com/b-mehta/topos/runs/556155330)) still get a green tick.