### PR TITLE
 check first for xz archives (closes #48)

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -145,23 +145,27 @@ def get_mathlib_archive(rev: str, url:str = '', force: bool = False,
     Return the archive Path. Will raise LeanDownloadError if nothing works.
     """
 
-    fname = rev + '.tar.gz'
-    path = DOT_MATHLIB/fname
+    # we check for xz archives first
+    fnames = [rev + '.tar.xz', rev + '.tar.gz']
+    paths = [DOT_MATHLIB/fname for fname in fnames]
     if not force:
         log.info('Looking for local mathlib oleans')
-        if path.exists():
-            log.info('Found local mathlib oleans')
-            return path
+        for path in paths:
+            if path.exists():
+                log.info('Found local mathlib oleans')
+                return path
     log.info('Looking for remote mathlib oleans')
-    try:
-        base_url = url or get_download_url()
-        download(base_url+fname, path)
-        log.info('Found mathlib oleans at '+base_url)
-        return path
-    except LeanDownloadError:
-        pass
+    for fname, path in zip(fnames, paths):
+        try:
+            base_url = url or get_download_url()
+            download(base_url+fname, path)
+            log.info('Found mathlib oleans at '+base_url)
+            return path
+        except LeanDownloadError:
+            pass
     log.info('Looking for GitHub mathlib oleans')
-    download(nightly_url(rev, repo), path)
+    # nightlies will only store gz archives
+    download(nightly_url(rev, repo), paths[1])
     log.info('Found GitHub mathlib oleans')
     return path
 
@@ -660,4 +664,3 @@ class LeanProject:
             G.nodes[node]['label'] = node
         self._import_graph = G
         return G
-

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -165,7 +165,7 @@ def get_mathlib_archive(rev: str, url:str = '', force: bool = False,
             pass
     log.info('Looking for GitHub mathlib oleans')
     # nightlies will only store gz archives
-    download(nightly_url(rev, repo), paths[1])
+    download(nightly_url(rev, repo), DOT_MATHLIB/(rev + '.tar.gz'))
     log.info('Found GitHub mathlib oleans')
     return path
 


### PR DESCRIPTION
I haven't tested this; I'm not exactly sure how to do that without messing up my normal mathlibtools install. This is the only method where .gz is mentioned, and the untar command is the same, so I think it's the only place that needs to be modified. But I'm not confident.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
