### PR TITLE
clarify behaviour of get-mathlib-cache

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -212,7 +212,7 @@ def get_cache(force: bool = False) -> None:
 
 @cli.command()
 def get_mathlib_cache() -> None:
-    """Get mathlib oleans without upgrading."""
+    """If mathlib is a dependency, upgrade mathlib lean and oleans to the version specified in the package toml."""
     try:
         proj().get_mathlib_olean()
     except (LeanDownloadError, FileNotFoundError) as err:


### PR DESCRIPTION
Is it the case that if there has been some renaming of mathlib files then one might have to delete-zombies afterwards? I'd also like to add the comment that this is what to use when someone else changes your toml with `leanproject up`.

TO CONTRIBUTORS:

Make sure you have:

  * [ ] reviewed and applied the coding style: [coding](https://github.com/leanprover/mathlib/blob/master/docs/style.md), [naming](https://github.com/leanprover/mathlib/blob/master/docs/naming.md)
  * [ ] for tactics:
     * [ ] added or adapted documentation in [tactics.md](https://github.com/leanprover/mathlib/blob/master/docs/tactics.md)
     * [ ] write an example of use of the new feature in [tactics.lean](https://github.com/leanprover/mathlib/blob/master/tests/tactics.lean)
  * [ ] make sure definitions and lemmas are put in the right files
  * [ ] make sure definitions and lemmas are not redundant

If this PR is related to a discussion on Zulip, please include a link in the discussion.

For reviewers: [code review check list](https://github.com/leanprover/mathlib/blob/master/docs/code-review.md)
