### PR TITLE
 Return correct download path for olean caches fetched from github. 

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -168,7 +168,8 @@ def get_mathlib_archive(rev: str, url:str = '', force: bool = False,
             pass
     log.info('Looking for GitHub mathlib oleans')
     # nightlies will only store gz archives
-    download(nightly_url(rev, repo), DOT_MATHLIB/(rev + '.tar.gz'))
+    path = DOT_MATHLIB / (rev + '.tar.gz')
+    download(nightly_url(rev, repo), path)
     log.info('Found GitHub mathlib oleans')
     return path
 


### PR DESCRIPTION
Fixes #62.