### PR TITLE
feat(scripts): installation script for MacOS

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+# Install dependencies
+brew install gmp coreutils python3 pipx
+
+# Install Elan
+curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
+source ~/.profile
+
+# Install mathlib supporting tools
+pipx ensurepath
+source ~/.bash_profile
+pipx install mathlibtools
+
+# Install and configure VS Code
+if ! which code; then
+brew cask install visual-studio-code
+fi
+code --install-extension jroesch.lean


### PR DESCRIPTION
This should be an all-in-one installation script for MacOS, similar to the script for Debian-based Linux distros. I ran these commands on a mostly clean MacOS machine during development, then tested it by `brew uninstall` and `pip uninstall`ing the packages, removing the dotfiles and deleting VS Code from the Applications folder before running the scripts. From the results during development, I expect the commands are robust enough to run on a system with some dependencies already installed.