### PR TITLE
fix(scripts/install_macos.sh): create `.bash_profile` if it doesn't yet exist

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -6,8 +6,14 @@
 brew install gmp coreutils python3 pipx
 
 # Install Elan
+# At startup, Bash sources .bash_profile, or if that doesn't exist, .profile.
+# Elan adds itself to the PATH in .bash_profile, or if that doesn't exist, .profile.
+# pipx only adds itself to the PATH in .bash_profile.
+# So we will create .bash_profile if it doesn't exist yet, ensuring .profile still gets loaded after installing pipx.
+if ! [ -r ~/.bash_profile ]; then
+echo '[ -r ~/.profile ] && source ~/.profile' >> ~/.bash_profile
+fi
 curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
-source ~/.profile
 
 # Install mathlib supporting tools
 pipx ensurepath


### PR DESCRIPTION
This prevents elan not being added to the path if it decides to modify `.profile` and pipx creates `.bash_profile` afterward. Confirmed to work by @semorrison.