### PR TITLE
feat(post-checkout): don't run get-mathlib-cache if in mathlib

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -230,7 +230,7 @@ def get_cache(force: bool = False) -> None:
                 'The repository is dirty, please commit changes before '
                 'fetching cache, or run this command with option --force.')
     except (LeanDownloadError, FileNotFoundError) as err:
-        handle_exception(err, 'Failed to fetch mathlib oleans')
+        handle_exception(err, 'Failed to fetch cached oleans')
 
 @cli.command()
 def get_mathlib_cache() -> None:

--- a/mathlibtools/post-checkout
+++ b/mathlibtools/post-checkout
@@ -8,12 +8,16 @@ NEW_HEAD=$2
 CHANGED_BRANCH=$3
 
 if [ "$CHANGED_BRANCH" -eq "1" ]; then
-    if /usr/bin/env python3 -c ""; then
+	if /usr/bin/env python3 -c ""; then
 		echo "Trying to fetch cached olean"
 		leanproject get-cache
-		leanproject get-mathlib-cache
+		# If the current project is not called "mathlib", then get a mathlib cache.
+		leanpkg dump | grep --quiet 'name = "mathlib"'
+		if [ $? -ne 0 ]; then
+			leanproject get-mathlib-cache
+		fi
 		leanproject delete-zombies
-    else
-        echo "'env python3' failed; not running post-checkout hook"
-    fi
+	else
+		echo "'env python3' failed; not running post-checkout hook"
+	fi
 fi


### PR DESCRIPTION
This PR:

1. in the post-checkout hook, checks if we're in mathlib (by inspecting leanpkg.toml), and does not run `get-mathlib-cache` if so
2. corrects an error message: when looking for a local cache and failing, it used to say "Failed to fetch mathlib oleans", and now says "Failed to fetch cached oleans".