### PR TITLE
SSH stuff

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -180,7 +180,7 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
                                  cache_url, force_download)
     except GitCommandError as err:
         # if full url is provided, do not retry with HTTPS
-        if ('Permission denied' in err.stderr) and not is_url:
+        if not is_url:
             log.info('SSH permission denied, trying HTTPS...')
             try:
                 name, url, branch, is_url = parse_project_name(original_name, ssh=False)

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -186,8 +186,8 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
                 name, url, branch, is_url = parse_project_name(original_name, ssh=False)
                 LeanProject.from_git_url(url, directory, branch, new_branch,
                                  cache_url, force_download)
-            except GitCommandError as err:
-                handle_exception(err, err.stderr)
+            except GitCommandError as e:
+                handle_exception(e, e.stderr)
         else:
             handle_exception(err, err.stderr)
 

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -181,7 +181,7 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
     except GitCommandError as err:
         # if full url is provided, do not retry with HTTPS
         if not is_url:
-            log.info('SSH permission denied, trying HTTPS...')
+            log.info('Error cloning via SSH, trying HTTPS...')
             try:
                 name, url, branch, is_url = parse_project_name(original_name, ssh=False)
                 LeanProject.from_git_url(url, directory, branch, new_branch,

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -6,16 +6,6 @@ from getpass import getpass
 
 from git.exc import GitCommandError # type: ignore
 
-# paramiko depends on cryptographic libs that easily fail in half-buggy
-# environments, so let's be careful
-try:
-    import paramiko # type: ignore
-    from paramiko.ssh_exception import (       # type: ignore
-        AuthenticationException, SSHException) # type: ignore
-    PARAMIKO_OK = True
-except ImportError:
-    PARAMIKO_OK = False
-
 import click
 
 from mathlibtools.lib import (LeanProject, log, LeanDirtyRepo,
@@ -124,9 +114,9 @@ def build() -> None:
     """Build the current project."""
     proj().build()
 
-def parse_project_name(name: str, ssh: bool = True) -> Tuple[str, str, str]:
+def parse_project_name(name: str, ssh: bool = True) -> Tuple[str, str, str, bool]:
     """Parse the name argument for get_project
-    Returns (name, url, branch).
+    Returns (name, url, branch, is_url).
     If name is not a full url, the returned url will be a https or ssh
     url depending on the boolean argument ssh.
     """
@@ -153,11 +143,13 @@ def parse_project_name(name: str, ssh: bool = True) -> Tuple[str, str, str]:
             url = 'git@github.com:'+org_name+'.git'
         else:
             url = 'https://github.com/'+org_name+'.git'
+        is_url = False
     else:
         url = name
         name = name.split('/')[-1].replace('.git', '')
+        is_url = True
 
-    return name, url, branch
+    return name, url, branch, is_url
 
 @cli.command(name='get')
 @click.argument('name')
@@ -176,25 +168,8 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
     This will fail if the branch does not exist. If you want to create a new
     branch, pass the `-b` option."""
 
-    # check whether we can ssh into GitHub
-    try:
-        assert PARAMIKO_OK
-        client = paramiko.client.SSHClient()
-        client.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
-        client.connect('github.com', username='git')
-        client.close()
-        ssh = True
-    except paramiko.PasswordRequiredException:
-        password = getpass('Please provide password for encrypted SSH private key: ')
-        client = paramiko.client.SSHClient()
-        client.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
-        client.connect('github.com', username='git', password=password)
-        client.close()
-        ssh = True
-    except (AssertionError, AuthenticationException, SSHException):
-        ssh = False
-
-    name, url, branch = parse_project_name(name, ssh)
+    original_name = name
+    name, url, branch, is_url = parse_project_name(original_name)
     if branch:
         name = name + '_' + branch
     directory = directory or name
@@ -204,7 +179,17 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
         LeanProject.from_git_url(url, directory, branch, new_branch,
                                  cache_url, force_download)
     except GitCommandError as err:
-        handle_exception(err, 'Git command failed')
+        # if full url is provided, do not retry with HTTPS
+        if ('Permission denied' in err.stderr) and not is_url:
+            log.info('SSH permission denied, trying HTTPS...')
+            try:
+                name, url, branch, is_url = parse_project_name(original_name, ssh=False)
+                LeanProject.from_git_url(url, directory, branch, new_branch,
+                                 cache_url, force_download)
+            except GitCommandError as err:
+                handle_exception(err, err.stderr)
+        else:
+            handle_exception(err, err.stderr)
 
 @cli.command()
 @click.option('--force', default=False, is_flag=True,

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "Operating System :: OS Independent" ],
     python_requires='>=3.5',
     install_requires=['toml>=0.10.0', 'PyGithub', 'certifi', 'gitpython>=2.1.11', 'requests',
-                      'Click', 'tqdm', 'paramiko>=2.7.0', 'networkx', 'pydot',
+                      'Click', 'tqdm', 'networkx', 'pydot',
                       'PyYAML>=3.13']
 )

--- a/tests/test_parse_project_name.py
+++ b/tests/test_parse_project_name.py
@@ -1,49 +1,57 @@
 from mathlibtools.leanproject import parse_project_name as P
 
 def test_name():
-    name, url, branch = P('tutorials')
+    name, url, branch, is_url = P('tutorials')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == ''
+    assert not is_url
 
 def test_org_name():
-    name, url, branch = P('leanprover-community/tutorials')
+    name, url, branch, is_url = P('leanprover-community/tutorials')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == ''
+    assert not is_url
 
 def test_https():
-    name, url, branch = P('https://github.com/leanprover-community/tutorials.git')
+    name, url, branch, is_url = P('https://github.com/leanprover-community/tutorials.git')
     assert name == 'tutorials'
     assert url == 'https://github.com/leanprover-community/tutorials.git'
     assert branch == ''
+    assert is_url
 
 def test_ssh():
-    name, url, branch = P('git@github.com:leanprover-community/tutorials.git')
+    name, url, branch, is_url = P('git@github.com:leanprover-community/tutorials.git')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == ''
+    assert is_url
 
 def test_name_branch():
-    name, url, branch = P('tutorials:foo')
+    name, url, branch, is_url = P('tutorials:foo')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == 'foo'
+    assert not is_url
 
 def test_org_name_branch():
-    name, url, branch = P('leanprover-community/tutorials:foo')
+    name, url, branch, is_url = P('leanprover-community/tutorials:foo')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == 'foo'
+    assert not is_url
 
 def test_https_branch():
-    name, url, branch = P('https://github.com/leanprover-community/tutorials.git:foo')
+    name, url, branch, is_url = P('https://github.com/leanprover-community/tutorials.git:foo')
     assert name == 'tutorials'
     assert url == 'https://github.com/leanprover-community/tutorials.git'
     assert branch == 'foo'
+    assert is_url
 
 def test_ssh_branch():
-    name, url, branch = P('git@github.com:leanprover-community/tutorials.git:foo')
+    name, url, branch, is_url = P('git@github.com:leanprover-community/tutorials.git:foo')
     assert name == 'tutorials'
     assert url == 'git@github.com:leanprover-community/tutorials.git'
     assert branch == 'foo'
+    assert is_url


### PR DESCRIPTION
This lets `git` handle all the stuff related to SSH rather than rolling it ourselves, and should work on all setups.

If a full url is not provided, it tries SSH first then falls back to HTTPS if `git` returns permission denied (user has not set up SSH, or SSH keyfile password entered incorrectly 3 times)

```
# User with no SSH keys configured
~> leanproject get tutorials
Cloning from git@github.com:leanprover-community/tutorials.git
SSH permission denied, trying HTTPS...
Cloning from https://github.com/leanprover-community/tutorials.git
```

```
~> leanproject get tutorials
Cloning from git@github.com:leanprover-community/tutorials.git
Enter passphrase for key '/home/user/.ssh/my_github_key':  # this message is from git
```

cf. #72 