### PR TITLE
Use appdirs for finding a platform-specific dir for mathlib caches.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,6 @@ buildPythonApplication {
   doCheck = false;
 
   propagatedBuildInputs = [
-    PyGithub GitPython toml click tqdm paramiko networkx pydot pyyaml
+    PyGithub GitPython toml click tqdm paramiko networkx pydot pyyaml appdirs
   ];
 }

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import Iterable, Union, List, Tuple, Optional, Dict
 from tempfile import TemporaryDirectory
 
+import appdirs # type: ignore
 import networkx as nx # type: ignore
 import requests
 from tqdm import tqdm # type: ignore
@@ -69,7 +70,9 @@ def nightly_url(rev: str, proj_repo: Optional[Repo] = None) -> str:
     return asset.browser_download_url
 
 
-DOT_MATHLIB = Path.home()/'.mathlib'
+DOT_MATHLIB = Path(
+    os.environ.get("MATHLIB_CACHE_DIR", appdirs.user_cache_dir("mathlib")),
+)
 AZURE_URL = 'https://oleanstorage.azureedge.net/mathlib/'
 
 DOT_MATHLIB.mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "Operating System :: OS Independent" ],
     python_requires='>=3.5',
     install_requires=['toml>=0.10.0', 'PyGithub', 'certifi', 'gitpython>=2.1.11', 'requests',
-                      'Click', 'tqdm', 'networkx', 'pydot',
+                      'Click', 'tqdm', 'networkx', 'pydot', 'appdirs',
                       'PyYAML>=3.13']
 )


### PR DESCRIPTION
Hello. Sending this to see if you'd be up for it.

This patch changes the directory previously used to store mathlib caches (`~/.mathlib`) to use [appdirs](https://pypi.org/project/appdirs/), a (simple somewhat widely used) package for finding a platform-specific directory to store things in (config, data, etc.).

E.g. on Linux, it'd instead go in `~/.cache/mathlib`.

Alongside that, I also added a `MATHLIB_CACHE_DIR` environment variable in case anyone wanted to move the directory to some other specific location.

Hopefully the above makes sense, comment welcome of course.