### PR TITLE
Add a missing import for leanproject decls.

### DIFF
--- a/mathlibtools/decls.lean
+++ b/mathlibtools/decls.lean
@@ -1,4 +1,4 @@
-import meta.expr system.io
+import data.list.sort meta.expr system.io
 
 open tactic declaration environment io io.fs (put_str_ln close)
 


### PR DESCRIPTION
Without this, leanproject decls complains there's no
list.split for me.