### PR TITLE
Add an automatic release-on-tag-push GHA.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,31 @@
+name: Packaging
+
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: python -m pip install build
+    - name: Create packages
+      run: python -m build .
+    - uses: actions/upload-artifact@master
+      with:
+        name: dist-${{ matrix.python-version }}
+        path: dist
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && runner.os == 'Linux'
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=40.6.0",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
In case you feel like taking me up on https://github.com/leanprover-community/mathlib-tools/pull/86#issuecomment-717572299 :)

If you want to use this, go to https://pypi.org/manage/account/token/, call it `mathlib-tools` or whatever, give it scope to upload to mathlib-tools, paste it here in GitHub in the Settings menu of this repo in your secrets, call it `pypi_password`, then when you bump a version, `git tag -a v0.11.0 -m "New Release"`, and when you push the tag it'll autoupload to PyPI.