### PR TITLE
Fix leanproject import-graph to not produce a graph with no edges

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -679,7 +679,7 @@ class LeanProject:
             imports = self.run(['lean', '--deps', str(path)])
             for imp in map(Path, imports.split()):
                 try:
-                    imp_rel = imp.relative_to(self.src_directory)
+                    imp_rel = imp.relative_to(self.src_directory.resolve())
                 except ValueError:
                     # This import is not from the project
                     continue


### PR DESCRIPTION
`src_directory` (on my machine) is a relative path, `lean --path` outputs absolute paths, and `relative_to` fails every time for `abs_path.relative_to(rel_path)`.

Tested on windows.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Diagnosing.20cyclic.20imports/near/218610115)