### PR TITLE
Update install-nix-action.

### DIFF
--- a/.github/workflows/test_nix.yml
+++ b/.github/workflows/test_nix.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v10
+      - uses: cachix/install-nix-action@v12
         with:
-          nix_path: nixpkgs=channel:nixos-20.03
+          nix_path: nixpkgs=channel:nixos-20.09
       - run: nix-build


### PR DESCRIPTION
Apparently github finally disabled the `add-path` command in actions, which caused the nix CI to fail.