### PR TITLE
dont clean a dirty mathlib project

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -582,11 +582,11 @@ class LeanProject:
 
     def clean_mathlib(self, force: bool = False) -> None:
         """Restore git sanity in mathlib"""
-        if self.is_mathlib and (not self.is_dirty or force):
-            assert self.repo
-            self.repo.head.reset(working_tree=True)
-            return
-        if self.mathlib_folder.exists():
+        if self.is_mathlib:
+            if not self.is_dirty or force:
+                assert self.repo
+                self.repo.head.reset(working_tree=True)
+        elif self.mathlib_folder.exists():
             mathlib = Repo(self.mathlib_folder)
             mathlib.head.reset(working_tree=True)
             mathlib.git.clean('-fd')


### PR DESCRIPTION
Currently if a user is working on mathlib and has a dirty repo and runs `leanproject build` the repo is cleaned.
This seems very bad to me (indeed I have once again lost a bunch of work due to mathlib-tools after https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/git.20hooks/near/210958859 and now this 😢).

This pr will change to not git clean a dirty mathlib.

However I would argue that we should in addition **always prompt the user for confirmation before doing anything destructive**, user error is always possible and a command that says "Build the current project." gives no hint that it will reset your git repo.

Example session:
```
+alex:~/tmp 🐌 leanproject get mathlib
Cloning from git@github.com:leanprover-community/mathlib.git
Enter passphrase for key '/Users/alex/.ssh/id_rsa': 
configuring mathlib 0.1
Looking for local mathlib oleans
Looking for remote mathlib oleans
Trying to download https://oleanstorage.azureedge.net/mathlib/d4bd4cdaabcfddfb4215dca26b317aa32030bf79.tar.xz to /Users/alex/.mathlib/d4bd4cdaabcfddfb4215dca26b317aa32030bf79.tar.xz
100%|████████████████████████████████████████| 32.5M/32.5M [00:05<00:00, 6.00MiB/s]
Found mathlib oleans at https://oleanstorage.azureedge.net/mathlib/
+alex:~/tmp 🐌 cd mathlib/
+alex:~/tmp/mathlib (master) 🐌 touch src/proof-of-rh.lean
+alex:~/tmp/mathlib (master) 🐌 git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
    src/proof-of-rh.lean

nothing added to commit but untracked files present (use "git add" to track)
+alex:~/tmp/mathlib (master) 🐌 git add src/proof-of-rh.lean 
+alex:~/tmp/mathlib (master +) 🐌 leanproject build
Building project mathlib
configuring mathlib 0.1
> lean --make src
+alex:~/tmp/mathlib (master) 🐌 git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
```

