### PR TITLE
feat(leanproject) add a function to list imports that can be removed due to being imported transitively

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from datetime import datetime
 from typing import Tuple, Optional
 from getpass import getpass
-import networkx as nx # type: ignore
 
 from git.exc import GitCommandError # type: ignore
 
@@ -288,20 +287,6 @@ def global_upgrade() -> None:
     proj = LeanProject.user_wide(cache_url, force_download)
     proj.upgrade_mathlib()
 
-def _import_graph_(to: str = None, from_: str = None) -> nx.DiGraph:
-    project = proj()
-    graph = project.import_graph
-    if to and from_:
-        G = graph.path(start=from_, end=to)
-    elif to:
-        G = graph.ancestors(to)
-    elif from_:
-        G = graph.descendants(from_)
-    else:
-        G = graph
-    return G
-
-
 @cli.command()
 @click.option('--to', 'to', default=None,
               help='Return only imports leading to this file.')
@@ -318,7 +303,16 @@ def import_graph(to: Optional[str], from_: Optional[str], output: str) -> None:
     By default the graph will be written to 'import_graph.dot'.
     For .dot, .pdf, .svg, or .png output you will need to install 'graphviz' first.
     """
-    G = _import_graph_(to, from_)
+    project = proj()
+    graph = project.import_graph
+    if to and from_:
+        G = graph.path(start=from_, end=to)
+    elif to:
+        G = graph.ancestors(to)
+    elif from_:
+        G = graph.descendants(from_)
+    else:
+        G = graph
     G.write(Path(output))
 
 
@@ -327,31 +321,14 @@ def import_graph(to: Optional[str], from_: Optional[str], output: str) -> None:
               help='Instead of printing a list of removable imports, print a sed script that can be run to remove the imports.')
 @click.argument('file', default=None, required=False)
 def reduce_imports(file: str, sed: bool = False) -> None:
-    """List imports that can be removed in the project.
+    """List imports that can be removed in the project in the format ("removable.import", "source.file")
 
     Argument '--file' should be specified as a
     Lean import (e.g. 'data.mv_polynomial') rather than a file name.
     """
-    G = _import_graph_(to = file)
-    H = nx.transitive_reduction(G)
-    if file:
-        fs = [file]
-    else:
-        fs = G.nodes
-    for f in fs:
-        if f == "all":
-            continue
-        Gf = [e for e in G.edges if e[1] == f]
-        Hf = [e for e in H.edges if e[1] == f]
-        o = [e for e in Gf if e[1] == f and e not in H.edges]
-        if sed:
-            for df in o:
-                # probably not the right command on osx
-                print("sed -i '/^import {line}$/d' src/{file}.lean".format(file=df[1].replace(".","/"), line=df[0]))
-        else:
-            if o:
-                print(o)
-
+    project = proj()
+    for l in project.reduce_imports(file=file, sed=sed):
+        print(l)
 
 @cli.command()
 @click.argument('path', default='')

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -327,8 +327,14 @@ def reduce_imports(file: str, sed: bool = False) -> None:
     Lean import (e.g. 'data.mv_polynomial') rather than a file name.
     """
     project = proj()
-    for l in project.reduce_imports(file=file, sed=sed):
-        print(l)
+    if sed:
+        print("# on mac use gsed instead of sed")
+        for l in project.reduce_imports_sed(file=file):
+            print(l)
+    else:
+        for t in project.reduce_imports(file=file):
+            print(t)
+
 
 @cli.command()
 @click.argument('path', default='')

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -321,7 +321,8 @@ def import_graph(to: Optional[str], from_: Optional[str], output: str) -> None:
               help='Instead of printing a list of removable imports, print a sed script that can be run to remove the imports.')
 @click.argument('file', default=None, required=False)
 def reduce_imports(file: str, sed: bool = False) -> None:
-    """List imports that can be removed in the project in the format ("removable.import", "source.file")
+    """List imports that can be removed in the project in the format 
+    `("source.file", ["removable.import", "another.removable.import"])`.
 
     Argument '--file' should be specified as a
     Lean import (e.g. 'data.mv_polynomial') rather than a file name.

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -661,9 +661,9 @@ class LeanProject:
                 continue
             Gf = [e for e in G.edges if e[1] == f]
             Hf = [e for e in H.edges if e[1] == f]
-            o = [e for e in Gf if e[1] == f and e not in H.edges]
+            o = [e[0] for e in Gf if e[1] == f and e not in H.edges]
             if o:
-                yield o
+                yield (f, o)
 
     def reduce_imports_sed(self, file: str) -> Iterable[str]:
         for o in self.reduce_imports(file):

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -11,7 +11,7 @@ import platform
 import subprocess
 import pickle
 from datetime import datetime
-from typing import Iterable, Union, List, Tuple, Optional, Dict, TYPE_CHECKING
+from typing import Iterable, Union, List, Tuple, Optional, Dict, TYPE_CHECKING, Any
 from tempfile import TemporaryDirectory
 
 import requests

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -666,10 +666,10 @@ class LeanProject:
                 yield (f, o)
 
     def reduce_imports_sed(self, file: str) -> Iterable[str]:
-        for o in self.reduce_imports(file):
-            for df in o:
+        for src, removable in self.reduce_imports(file):
+            for r in removable:
                 # probably not the right command on osx
-                yield "sed -i '/^import {line}$/d' src/{file}.lean".format(file=df[1].replace(".","/"), line=df[0])
+                yield "sed -i '/^import {line}$/d' src/{file}.lean".format(file=src.replace(".","/"), line=r)
 
     def make_all(self) -> None:
         """Creates all.lean importing everything from the project"""

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -639,7 +639,7 @@ class LeanProject:
         self._import_graph = G
         return G
 
-    def reduce_imports(self, file: str) -> Iterable[List[Any]]:
+    def reduce_imports(self, file: str) -> Iterable[List[Tuple[str,str]]]:
         # Importing networkx slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -634,7 +634,7 @@ class LeanProject:
         self._import_graph = G
         return G
 
-    def reduce_imports(self, file: str, sed: bool = False) -> Iterable[Any]:
+    def reduce_imports(self, file: str) -> Iterable[List[Any]]:
         # Importing networkx slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore
@@ -652,13 +652,14 @@ class LeanProject:
             Gf = [e for e in G.edges if e[1] == f]
             Hf = [e for e in H.edges if e[1] == f]
             o = [e for e in Gf if e[1] == f and e not in H.edges]
-            if sed:
-                for df in o:
-                    # probably not the right command on osx
-                    yield "sed -i '/^import {line}$/d' src/{file}.lean".format(file=df[1].replace(".","/"), line=df[0])
-            else:
-                if o:
-                    yield o
+            if o:
+                yield o
+
+    def reduce_imports_sed(self, file: str) -> Iterable[str]:
+        for o in self.reduce_imports(file):
+            for df in o:
+                # probably not the right command on osx
+                yield "sed -i '/^import {line}$/d' src/{file}.lean".format(file=df[1].replace(".","/"), line=df[0])
 
     def make_all(self) -> None:
         """Creates all.lean importing everything from the project"""

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -634,7 +634,7 @@ class LeanProject:
         self._import_graph = G
         return G
 
-    def reduce_imports(self, file: str, sed: bool = False) -> Iterable[str]:
+    def reduce_imports(self, file: str, sed: bool = False) -> Iterable[Any]:
         # Importing networkx slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -634,6 +634,32 @@ class LeanProject:
         self._import_graph = G
         return G
 
+    def reduce_imports(self, file: str, sed: bool = False) -> Iterable[str]:
+        # Importing networkx slow, so don't do it until this function
+        # is called.
+        import networkx as nx # type: ignore
+        G = self.import_graph
+        if file:
+            G = G.ancestors(file)
+        H = nx.transitive_reduction(G)
+        if file:
+            fs = [file]
+        else:
+            fs = G.nodes
+        for f in fs:
+            if f == "all":
+                continue
+            Gf = [e for e in G.edges if e[1] == f]
+            Hf = [e for e in H.edges if e[1] == f]
+            o = [e for e in Gf if e[1] == f and e not in H.edges]
+            if sed:
+                for df in o:
+                    # probably not the right command on osx
+                    yield "sed -i '/^import {line}$/d' src/{file}.lean".format(file=df[1].replace(".","/"), line=df[0])
+            else:
+                if o:
+                    yield o
+
     def make_all(self) -> None:
         """Creates all.lean importing everything from the project"""
         with (self.src_directory/'all.lean').open('w') as all_file:

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -11,7 +11,7 @@ import platform
 import subprocess
 import pickle
 from datetime import datetime
-from typing import Iterable, IO, Union, List, Tuple, Optional, Dict, TYPE_CHECKING, Any
+from typing import Iterable, IO, Union, List, Tuple, Optional, Dict, TYPE_CHECKING
 from tempfile import TemporaryDirectory
 
 import requests

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -639,7 +639,7 @@ class LeanProject:
         self._import_graph = G
         return G
 
-    def reduce_imports(self, file: str) -> Iterable[List[Tuple[str,str]]]:
+    def reduce_imports(self, file: str) -> Iterable[List[Tuple[str, str]]]:
         # Importing networkx slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -639,7 +639,7 @@ class LeanProject:
         self._import_graph = G
         return G
 
-    def reduce_imports(self, file: str) -> Iterable[List[Tuple[str, str]]]:
+    def reduce_imports(self, file: str) -> Iterable[Tuple[str, List[str]]]:
         """
         An iterator over files with removable imports, for each file yielding
         a list of removable imports in the format

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -643,7 +643,7 @@ class LeanProject:
         """
         An iterator over files with removable imports, for each file yielding
         a list of removable imports in the format
-        `("removable.import", "source.file")`.
+        `("source.file", ["removable.import", "another.removable.import"])`.
         """
         # Importing networkx slow, so don't do it until this function
         # is called.

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -645,7 +645,7 @@ class LeanProject:
         a list of removable imports in the format
         `("source.file", ["removable.import", "another.removable.import"])`.
         """
-        # Importing networkx slow, so don't do it until this function
+        # Importing networkx is slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore
         G = self.import_graph

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -640,6 +640,11 @@ class LeanProject:
         return G
 
     def reduce_imports(self, file: str) -> Iterable[List[Tuple[str, str]]]:
+        """
+        An iterator over files with removable imports, for each file yielding
+        a list of removable imports in the format
+        `("removable.import", "source.file")`.
+        """
         # Importing networkx slow, so don't do it until this function
         # is called.
         import networkx as nx # type: ignore

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -661,7 +661,7 @@ class LeanProject:
                 continue
             Gf = [e for e in G.edges if e[1] == f]
             Hf = [e for e in H.edges if e[1] == f]
-            o = [e[0] for e in Gf if e[1] == f and e not in H.edges]
+            o = [e[0] for e in Gf if e not in Hf]
             if o:
                 yield (f, o)
 


### PR DESCRIPTION
`leanproject reduce-imports --file foo.bar` will list imports in `foo/bar.lean` that are imported by other imports of `foo.bar` and could therefore be removed, `--sed` will print out a sed script to cut out those lines.