### PR TITLE
fix(install_macos.sh): remove deprecated brew cask install

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -22,6 +22,6 @@ pipx install mathlibtools
 
 # Install and configure VS Code
 if ! which code; then
-brew cask install visual-studio-code
+brew install --cask visual-studio-code
 fi
 code --install-extension jroesch.lean


### PR DESCRIPTION
See also https://github.com/Homebrew/discussions/discussions/340

---

@rwbarton and I helped some people to install Lean on their computers. We ran into two problems:

* One error `Calling brew cask install is disabled! Use brew install [--cask] instead.`
The script worked after replacing `brew cask install visual-studio-code` by `brew install --cask visual-studio-code`
See also e.g. https://github.com/Homebrew/discussions/discussions/340

* The other error was that `leanpkg` and `elan` were not in the path after installation, but I think that problem has the same cause. We didn't run `source ~/.profile` after correctly installing mathlibtools.

@Vierkantor @PatrickMassot 