### PR TITLE
Do not import networkx (and transitively numpy) until it is needed

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 from typing import Optional
+import tempfile
+import subprocess
 
 import networkx as nx # type: ignore
 

--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from typing import Optional
+
+import networkx as nx # type: ignore
+
+class ImportGraph(nx.DiGraph):
+    def __init__(self, base_path: Optional[Path] = None) -> None:
+        """A Lean project import graph."""
+        super().__init__(self)
+        self.base_path = base_path or Path('.')
+
+    def to_dot(self, path: Optional[Path] = None) -> None:
+        """Writes itself to a graphviz dot file."""
+        path = path or self.base_path/'import_graph.dot'
+        nx.drawing.nx_pydot.to_pydot(self).write_dot(str(path))
+
+    def to_gexf(self, path: Optional[Path] = None) -> None:
+        """Writes itself to a gexf dot file, suitable for Gephi."""
+        path = path or self.base_path/'import_graph.gexf'
+        nx.write_gexf(self, str(path))
+
+    def to_graphml(self, path: Optional[Path] = None) -> None:
+        """Writes itself to a gexf dot file, suitable for yEd."""
+        path = path or self.base_path/'import_graph.graphml'
+        nx.write_graphml(self, str(path))
+
+    def write(self, path: Path):
+        if path.suffix == '.dot':
+            self.to_dot(path)
+        elif path.suffix == '.gexf':
+            self.to_gexf(path)
+        elif path.suffix == '.graphml':
+            self.to_graphml(path)
+        elif path.suffix in ['.pdf', '.svg', '.png']:
+            dot_format = '-T' + path.suffix[1:]
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                tmpf = Path(tmpdirname)/'tmp.dot'
+                self.to_dot(tmpf)
+                with path.open('w') as outf:
+                    subprocess.run(['dot', dot_format, str(tmpf)],
+                                   stdout=outf)
+        else:
+            raise ValueError('Unsupported graph output format. '
+                             'Use .dot, .gexf, .graphml or a valid '
+                             'graphviz output format (eg. .pdf).')
+
+    def ancestors(self, node: str) -> 'ImportGraph':
+        """Returns the subgraph leading to node."""
+        H = self.subgraph(nx.ancestors(self, node).union([node]))
+        H.base_path = self.base_path
+        return H
+
+    def descendants(self, node: str) -> 'ImportGraph':
+        """Returns the subgraph descending from node."""
+        H = self.subgraph(nx.descendants(self, node).union([node]))
+        H.base_path = self.base_path
+        return H
+
+    def path(self, start: str, end: str) -> 'ImportGraph':
+        """Returns the subgraph descending from the start node and used by the
+        end node."""
+        D = self.descendants(start)
+        A = self.ancestors(end)
+        H = self.subgraph(set(D.nodes).intersection(A.nodes))
+        H.base_path = self.base_path
+        return H

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -11,15 +11,17 @@ import platform
 import subprocess
 import pickle
 from datetime import datetime
-from typing import Iterable, Union, List, Tuple, Optional, Dict
+from typing import Iterable, Union, List, Tuple, Optional, Dict, TYPE_CHECKING
 from tempfile import TemporaryDirectory
 
-import networkx as nx # type: ignore
 import requests
 from tqdm import tqdm # type: ignore
 import toml
 import yaml
 from git import Repo, InvalidGitRepositoryError, GitCommandError # type: ignore
+
+if TYPE_CHECKING:
+    from mathlibtools.import_graph import ImportGraph
 
 from mathlibtools.delayed_interrupt import DelayedInterrupt
 from mathlibtools.auth_github import auth_github, Github
@@ -209,68 +211,6 @@ def find_root(path: Path) -> Path:
         return find_root(parent)
     else:
         raise InvalidLeanProject('Could not find a leanpkg.toml')
-
-class ImportGraph(nx.DiGraph):
-    def __init__(self, base_path: Optional[Path] = None) -> None:
-        """A Lean project import graph."""
-        super().__init__(self)
-        self.base_path = base_path or Path('.')
-
-    def to_dot(self, path: Optional[Path] = None) -> None:
-        """Writes itself to a graphviz dot file."""
-        path = path or self.base_path/'import_graph.dot'
-        nx.drawing.nx_pydot.to_pydot(self).write_dot(str(path))
-
-    def to_gexf(self, path: Optional[Path] = None) -> None:
-        """Writes itself to a gexf dot file, suitable for Gephi."""
-        path = path or self.base_path/'import_graph.gexf'
-        nx.write_gexf(self, str(path))
-
-    def to_graphml(self, path: Optional[Path] = None) -> None:
-        """Writes itself to a gexf dot file, suitable for yEd."""
-        path = path or self.base_path/'import_graph.graphml'
-        nx.write_graphml(self, str(path))
-
-    def write(self, path: Path):
-        if path.suffix == '.dot':
-            self.to_dot(path)
-        elif path.suffix == '.gexf':
-            self.to_gexf(path)
-        elif path.suffix == '.graphml':
-            self.to_graphml(path)
-        elif path.suffix in ['.pdf', '.svg', '.png']:
-            dot_format = '-T' + path.suffix[1:]
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                tmpf = Path(tmpdirname)/'tmp.dot'
-                self.to_dot(tmpf)
-                with path.open('w') as outf:
-                    subprocess.run(['dot', dot_format, str(tmpf)],
-                                   stdout=outf)
-        else:
-            raise ValueError('Unsupported graph output format. '
-                             'Use .dot, .gexf, .graphml or a valid '
-                             'graphviz output format (eg. .pdf).')
-
-    def ancestors(self, node: str) -> 'ImportGraph':
-        """Returns the subgraph leading to node."""
-        H = self.subgraph(nx.ancestors(self, node).union([node]))
-        H.base_path = self.base_path
-        return H
-
-    def descendants(self, node: str) -> 'ImportGraph':
-        """Returns the subgraph descending from node."""
-        H = self.subgraph(nx.descendants(self, node).union([node]))
-        H.base_path = self.base_path
-        return H
-
-    def path(self, start: str, end: str) -> 'ImportGraph':
-        """Returns the subgraph descending from the start node and used by the
-        end node."""
-        D = self.descendants(start)
-        A = self.ancestors(end)
-        H = self.subgraph(set(D.nodes).intersection(A.nodes))
-        H.base_path = self.base_path
-        return H
 
 
 class DeclInfo:
@@ -668,7 +608,11 @@ class LeanProject:
         return (check_core_timestamps(self.toolchain), mathlib_ok)
 
     @property
-    def import_graph(self) -> ImportGraph:
+    def import_graph(self) -> 'ImportGraph':
+        # Importing networkx + numpy is slow, so don't do it until this function
+        # is called.
+        from mathlibtools.import_graph import ImportGraph
+
         if self._import_graph:
             return self._import_graph
         G = ImportGraph(self.directory)


### PR DESCRIPTION
This moves `ImportGraph`, along with the imports needed to define it, to a new file.
`LeanProject.import_graph` imports this file when called.

This speeds up `leanproject -h` from 3.4s to 1.9s on my machine