### PR TITLE
fix(mk_cache): make xz archive instead of bz2

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -82,7 +82,7 @@ if not DOWNLOAD_URL_FILE.exists():
     set_download_url()
 
 def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
-    """Creates, as target, a tar.bz2 archive containing all paths from src,
+    """Creates, as target, a tar.gz archive containing all paths from src,
     relative to the folder root"""
     try:
         target.unlink()
@@ -91,7 +91,7 @@ def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
     cur_dir = Path.cwd()
     with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
         os.chdir(str(root))
-        ar = tarfile.open(str(target), 'w|bz2')
+        ar = tarfile.open(str(target), 'w|gz')
         for src in srcs:
             ar.add(str(src.relative_to(root)))
         ar.close()

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -82,7 +82,7 @@ if not DOWNLOAD_URL_FILE.exists():
     set_download_url()
 
 def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
-    """Creates, as target, a tar.gz archive containing all paths from src,
+    """Creates, as target, a tar.xz archive containing all paths from src,
     relative to the folder root"""
     try:
         target.unlink()
@@ -91,7 +91,7 @@ def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
     cur_dir = Path.cwd()
     with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
         os.chdir(str(root))
-        ar = tarfile.open(str(target), 'w|gz')
+        ar = tarfile.open(str(target), 'w|xz')
         for src in srcs:
             ar.add(str(src.relative_to(root)))
         ar.close()

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -464,7 +464,7 @@ class LeanProject:
             raise ValueError('This project has no git commit.')
         tgt_folder = DOT_MATHLIB if self.is_mathlib else self.directory/'_cache'
         tgt_folder.mkdir(exist_ok=True)
-        archive = tgt_folder/(str(self.rev) + '.tar.bz2')
+        archive = tgt_folder/(str(self.rev) + '.tar.xz')
         if archive.exists() and not force:
             log.info('Cache for revision {} already exists'.format(self.rev))
             return
@@ -485,7 +485,7 @@ class LeanProject:
         else:
             if rev:
                 rev = self.repo.rev_parse(rev).hexsha
-            unpack_archive(self.directory/'_cache'/(rev or str(self.rev)+'.tar.bz2'),
+            unpack_archive(self.directory/'_cache'/(rev or str(self.rev)+'.tar.xz'),
                            self.directory)
 
     @classmethod


### PR DESCRIPTION
Running `leanproject mk_cache` followed by `leanproject get_cache` in a mathlib repo failed, since `get_cache` only looked for an `xz` file. IIRC we deprecated all other formats. It makes sense for `mk_cache` to use the same format as mathlib CI. This will probably cause minor breakage on upgrade (if anyone actually uses this) but nothing too big.