### PR TITLE
Use --cask flag instead of cask command.

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -22,6 +22,6 @@ pipx install mathlibtools
 
 # Install and configure VS Code
 if ! which code; then
-brew cask install visual-studio-code
+brew install --cask visual-studio-code
 fi
 code --install-extension jroesch.lean


### PR DESCRIPTION
Folding in a [change from Homebrew 2.6.0+](https://brew.sh/2020/12/01/homebrew-2.6.0/), which caused the macOS script to bottom out when trying to install VS Code.

> All `brew cask` commands have been deprecated in favor of `brew` commands (with `--cask`) when necessary