### PR TITLE
Simplify the Install Script on macOS to use brew

### DIFF
--- a/.github/workflows/test_install_scripts.yml
+++ b/.github/workflows/test_install_scripts.yml
@@ -18,3 +18,5 @@ jobs:
       run: lean --version
     - name: Check that leanproject runs
       run: leanproject --help
+    - name: Check that VSCode exists
+      run: code --version

--- a/.github/workflows/test_install_scripts.yml
+++ b/.github/workflows/test_install_scripts.yml
@@ -30,5 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version.name }}
     - name: Install mathlib-tools
       run: ./scripts/install_macos.sh
+    - name: Check that lean runs
+      run: lean --version
     - name: Check that leanproject runs
       run: leanproject --help

--- a/.github/workflows/test_install_scripts.yml
+++ b/.github/workflows/test_install_scripts.yml
@@ -9,25 +9,9 @@ on:
 jobs:
   install_macos:
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - name: 3.6
-            toxenv: py36
-          - name: 3.7
-            toxenv: py37
-          - name: 3.8
-            toxenv: py38
-          - name: 3.9
-            toxenv: py39
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version.name }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version.name }}
     - name: Install mathlib-tools
       run: ./scripts/install_macos.sh
     - name: Check that lean runs

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
 # Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+set -e
 
-# Install dependencies
-brew install gmp coreutils python3 pipx
-
-# Install Elan
-# At startup, Bash sources .bash_profile, or if that doesn't exist, .profile.
-# Elan adds itself to the PATH in .bash_profile, or if that doesn't exist, .profile.
-# pipx only adds itself to the PATH in .bash_profile.
-# So we will create .bash_profile if it doesn't exist yet, ensuring .profile still gets loaded after installing pipx.
-if ! [ -r ~/.bash_profile ]; then
-echo '[ -r ~/.profile ] && source ~/.profile' >> ~/.bash_profile
+if ! which brew > /dev/null; then
+    # Install Homebrew
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+else
+    # Update it, in case it has been ages since it's been updated
+    brew update
 fi
-curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
 
-# Install mathlib supporting tools
-pipx ensurepath
-source ~/.bash_profile
-pipx install mathlibtools
+brew install elan mathlibtools
+elan toolchain install stable
+elan default stable
 
 # Install and configure VS Code
-if ! which code; then
-brew install --cask visual-studio-code
+if ! which code > /dev/null; then
+    brew install --cask visual-studio-code
 fi
 code --install-extension jroesch.lean


### PR DESCRIPTION
With `elan` and `mathlibtools` itself in Homebrew now, we can cut some of this down.