### PR TITLE
Update macOS installer

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -1,24 +1,11 @@
 #!/bin/bash
-# Install Homebrew
+# Install Homebrew if it's not yet installed
+if ! which brew; then
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-
-# Install dependencies
-brew install gmp coreutils python3 pipx
-
-# Install Elan
-# At startup, Bash sources .bash_profile, or if that doesn't exist, .profile.
-# Elan adds itself to the PATH in .bash_profile, or if that doesn't exist, .profile.
-# pipx only adds itself to the PATH in .bash_profile.
-# So we will create .bash_profile if it doesn't exist yet, ensuring .profile still gets loaded after installing pipx.
-if ! [ -r ~/.bash_profile ]; then
-echo '[ -r ~/.profile ] && source ~/.profile' >> ~/.bash_profile
 fi
-curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh
 
-# Install mathlib supporting tools
-pipx ensurepath
-source ~/.bash_profile
-pipx install mathlibtools
+# Install elan and mathlibtools
+brew install elan mathlibtools
 
 # Install and configure VS Code
 if ! which code; then


### PR DESCRIPTION
Everything is available from Homebrew now, so it seems simpler to
install everything using that. I've omitted the dependencies (gmp,
coreutils and python3), as brew should install those too if they're not
available. (I don't mind putting them back too if you prefer.)

Also, check that there is no `brew` command before trying to run the
Homebrew install script, as I'm not actually certain the script is
idempotent.