### PR TITLE
feat(leanproject): download to a tempfile

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,6 @@ buildPythonApplication {
   doCheck = false;
 
   propagatedBuildInputs = [
-    PyGithub GitPython toml click tqdm paramiko networkx pydot pyyaml
+    PyGithub GitPython toml click tqdm paramiko networkx pydot pyyaml atomicwrites
   ];
 }

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -126,10 +126,13 @@ def download_to_file(url: str, tgt: IO) -> None:
 
 def download(url: str, target: Path) -> None:
     """Download from url into the target path"""
-    with tempfile.NamedTemporaryFile(mode='wb') as temp:
-        log.info('Trying to download {} to {} (temporary file: {})'.format(url, target, temp.name))
+    temp = tempfile.NamedTemporaryFile(mode='wb', delete=False)
+    log.info('Trying to download {} to {} (temporary file: {})'.format(url, target, temp.name))
+    try:
         download_to_file(url, temp)
         shutil.copy(temp.name, target)
+    finally:
+        os.remove(temp.name)
 
 def get_mathlib_archive(rev: str, url:str = '', force: bool = False) -> Path:
     """Download a mathlib archive for revision rev into .mathlib

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=['toml>=0.10.0', 'PyGithub', 'certifi', 'gitpython>=2.1.11', 'requests',
                       'Click', 'tqdm', 'networkx', 'pydot',
-                      'PyYAML>=3.13']
+                      'PyYAML>=3.13', 'atomicwrites']
 )


### PR DESCRIPTION
If leanproject is downloading a file (e.g. mathlib oleans) and gets interrupted, we should not keep around the broken archive file. Otherwise, if you re-run the command, leanproject will think the partial download is in fact a complete archive and it will try to extract a broken file.

This PR fixes that issue by creating a temporary file in the `download` function and moving this over the target file when the download has completed successfully.

I have successfully tested the changes on my Linux computer by running `leanproject get-cache` and interrupting the download, then running `leanproject get-cache` again and verifying the oleans are available. Since atomic operations are OS-specific, someone with access to a Windows computer should definitely test this PR as well.
(Is there a way to insert a connection error in the middle of a download automatically, so we can add this functionality to the `tox` tests?)