### PR TITLE
feat(get-cache): Perform a topological walk to find all viable caches

### DIFF
--- a/mathlibtools/git_helpers.py
+++ b/mathlibtools/git_helpers.py
@@ -1,4 +1,4 @@
-import git
+import git   # type: ignore
 from typing import Callable, Iterator, Tuple, List
 
 

--- a/mathlibtools/git_helpers.py
+++ b/mathlibtools/git_helpers.py
@@ -2,6 +2,11 @@ import git   # type: ignore
 from typing import Callable, Iterator, Tuple, List
 
 
+def short_sha(rev: git.Commit) -> str:
+    """ Truncate `rev.hexsha` without ambiguity """
+    return rev.repo.git.rev_parse(rev.hexsha, short=True)
+
+
 def visit_ancestors(rev: git.Commit) -> Iterator[Tuple[git.Commit, Callable]]:
     r"""
     Iterate over the ancestors of the commit `rev` in topological order, with

--- a/mathlibtools/git_helpers.py
+++ b/mathlibtools/git_helpers.py
@@ -1,7 +1,5 @@
 import git
-from typing import Callable, TypeVar, Iterator, Tuple
-
-T = TypeVar('T')
+from typing import Callable, Iterator, Tuple, List
 
 
 def visit_ancestors(rev: git.Commit) -> Iterator[Tuple[git.Commit, Callable]]:
@@ -20,12 +18,7 @@ def visit_ancestors(rev: git.Commit) -> Iterator[Tuple[git.Commit, Callable]]:
     where ``A`` is the root commit and ``K`` and ``L`` are tips of branches.
     The following code runs against this commit graph
 
-    >>> def filter_fun(c):
-    ...     print('visited', c)
-    ...     if c in {B, F, G}:
-    ...         return c
     >>> for c, prune in visit_ancestors(L):
-    ...     print('visited', c)
     ...     if c in {B, F, G}:
     ...         prune()
     ...         print('found  ', c)
@@ -33,18 +26,18 @@ def visit_ancestors(rev: git.Commit) -> Iterator[Tuple[git.Commit, Callable]]:
     ...         print('visited', c)
     visited L
     visited J
-    visited I
-    visited E
-    found   F
     visited H
+    visited I
+    found   F
     found   G
+    visited E
 
     The exact order these commits appear in depends on the order of parents in
     merge commits, but independent of this ``B`` will never be visited as it is
     a parent of ``F`` and ``G``, and the sort order is topological.
     """
     repo = rev.repo
-    pruned_commits = []  # the commits to ignore along with their ancestors
+    pruned_commits : List[git.Commit] = []  # the commits to ignore along with their ancestors
     skip_n = 0  # the index to resume the iteration
     while True:
         args = [rev] + ['--not'] + pruned_commits

--- a/mathlibtools/git_helpers.py
+++ b/mathlibtools/git_helpers.py
@@ -1,0 +1,67 @@
+import git
+from typing import Callable, TypeVar, Iterator, Tuple
+
+T = TypeVar('T')
+
+
+def visit_ancestors(rev: git.Commit) -> Iterator[Tuple[git.Commit, Callable]]:
+    r"""
+    Iterate over the ancestors of the commit `rev` in topological order, with
+    the option to prune parents of visited commits.
+
+    Consider the commit graph::
+
+        A -- B -- E -- I -- J -- L
+              \       /    /
+               C --- F -- H
+                \        /
+                 D ---- G --- K
+
+    where ``A`` is the root commit and ``K`` and ``L`` are tips of branches.
+    The following code runs against this commit graph
+
+    >>> def filter_fun(c):
+    ...     print('visited', c)
+    ...     if c in {B, F, G}:
+    ...         return c
+    >>> for c, prune in visit_ancestors(L):
+    ...     print('visited', c)
+    ...     if c in {B, F, G}:
+    ...         prune()
+    ...         print('found  ', c)
+    ...     else:
+    ...         print('visited', c)
+    visited L
+    visited J
+    visited I
+    visited E
+    found   F
+    visited H
+    found   G
+
+    The exact order these commits appear in depends on the order of parents in
+    merge commits, but independent of this ``B`` will never be visited as it is
+    a parent of ``F`` and ``G``, and the sort order is topological.
+    """
+    repo = rev.repo
+    pruned_commits = []  # the commits to ignore along with their ancestors
+    skip_n = 0  # the index to resume the iteration
+    while True:
+        args = [rev] + ['--not'] + pruned_commits
+        proc = repo.git.rev_list(*args, as_process=True, skip=skip_n, topo_order=True)
+        for c in git.Commit._iter_from_process_or_stream(repo, proc):
+            # build a temporary function to hand back to the user
+            do_prune = False
+            def prune():
+                nonlocal do_prune
+                do_prune = True
+            yield c, prune
+            if do_prune:
+                pruned_commits.append(c)
+                break
+            else:
+                # start after this commit next time we restart the search
+                skip_n += 1
+        else:
+            # all ancestors found
+            return

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -220,9 +220,9 @@ def get_cache(rev: Optional[str], force: bool, fallback: str) -> None:
       download-first: show all fallback caches, download and apply the first
       download-all: show and download all fallback caches, apply the first.
     """
-    fallback = CacheFallback(fallback)
+    fallback_enum = CacheFallback(fallback)
     try:
-        proj().get_cache(rev, force, fallback)
+        proj().get_cache(rev, force, fallback_enum)
     except LeanDirtyRepo as err:
         handle_exception(err,
                 'The repository is dirty, please commit changes before '
@@ -243,10 +243,10 @@ def get_mathlib_cache(rev: Optional[str], fallback: str) -> None:
       show: show but do not download possible fallback caches
       download-first: show all fallback caches, download and apply the first
       download-all: show and download all fallback caches, apply the first."""
-    fallback = CacheFallback(fallback)
+    fallback_enum = CacheFallback(fallback)
     project = proj()
     try:
-        project.get_mathlib_olean(rev, fallback)
+        project.get_mathlib_olean(rev, fallback_enum)
     except (LeanDownloadError, FileNotFoundError) as err:
         handle_exception(err, 'Failed to fetch mathlib oleans')
 

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -411,15 +411,20 @@ class LeanProject:
         found_commit, archive = archives[0]
 
         if len(archives) > 1:
-            archive_str = ''.join([f'\n * {r.hexsha}' for r, ar in archives])
+            archive_items = ''.join([f'\n * {r.hexsha}' for r, ar in archives])
+            commit_args = ''.join([f' {r.hexsha}^!' for r, ar in archives])
             log.warn(
                 f"No cache was available for {commit.hexsha}.\n"
-                f"There are multiple viable caches from parent commits, using the first:{archive_str}\n"
-                f"All caches have been downloaded; use `get-cache --rev` to select a different one.")
+                f"There are multiple viable caches from parent commits, using the first:{archive_items}\n"
+                f"All caches have been downloaded; use `get-cache --rev` to select a different one.\n"
+                f"To see the commits in question, run:\n"
+                f"  git log --graph {commit.hexsha}{commit_args}")
         elif found_commit != commit:
             log.warn(
                 f"No cache was available for {commit.hexsha}. "
-                f"Using the cache for the ancestor {found_commit.hexsha}.")
+                f"Using the cache for the ancestor {found_commit.hexsha}.\n"
+                f"To see the intermediate commits, run:\n"
+                f"  git log --graph {commit.hexsha} {found_commit.hexsha}^!")
 
         self.clean_mathlib()
         self.mathlib_folder.mkdir(parents=True, exist_ok=True)

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -263,8 +263,8 @@ class CacheLocator:
             if fallback == CacheFallback.DOWNLOAD_ALL:
                 log.info("Downloading all caches")
                 with concurrent.futures.ThreadPoolExecutor() as executor:
-                    caches = list(executor.map(lambda c: c.download(), caches))
-                return caches[0]
+                    local_caches = list(executor.map(lambda c: c.download(), caches))
+                return local_caches[0]
             elif fallback == CacheFallback.DOWNLOAD_FIRST:
                 log.info("Downloading first cache")
                 return caches[0].download()

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -229,8 +229,9 @@ class CacheLocator:
             cache = self.find_exact(rev)
             if not cache:
                 raise LeanDownloadError(f"No cache was available for {short_sha(rev)}.\n")
-            log.info("Downloading matching cache")
-            return cache.download()
+            with cache:
+                log.info("Downloading matching cache")
+                return cache.download()
 
         # Otherwise, do a search. This will open as many HTTP connections as
         # necessary, which the `with` statement cleans up.

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -217,6 +217,9 @@ class CacheLocator:
                     prune()  # do not visit the ancestors of this commit
             return stack.pop_all(), caches
 
+        # https://github.com/python/mypy/issues/7726
+        assert False
+
     def find_local_with_fallback(self, rev: Commit, fallback: CacheFallback) -> LocalOleanCache:
         """
         Find (or download) a local cache for `rev` using the provided fallback strategy.
@@ -274,6 +277,8 @@ class CacheLocator:
             else:
                 raise RuntimeError('Invalid fallback argument')
 
+        # https://github.com/python/mypy/issues/7726
+        assert False
 
 def parse_version(version: str) -> VersionTuple:
     """Turn a lean version string into a tuple of integers or raise

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -382,6 +382,7 @@ class LeanProject:
         # Just in case the user broke the workflow (for instance git clone
         # mathlib by hand and then run `leanproject get-cache`)
         if self.is_mathlib:
+            assert self.repo
             repo = self.repo
         else:
             repo = Repo(self.mathlib_folder)

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 from mathlibtools.delayed_interrupt import DelayedInterrupt
 from mathlibtools.auth_github import auth_github, Github
-from mathlibtools.git_helpers import visit_ancestors
+from mathlibtools.git_helpers import visit_ancestors, short_sha
 
 log = logging.getLogger("Mathlib tools")
 log.setLevel(logging.INFO)
@@ -398,7 +398,7 @@ class LeanProject:
                 archive = get_mathlib_archive(parent_commit.hexsha,
                                               self.cache_url, self.force_download)
             except LeanDownloadError:
-                log.info(f"No cache available for revision {parent_commit.hexsha}")
+                log.info(f"No cache available for revision {short_sha(parent_commit)}")
                 pass
             else:
                 archives.append((parent_commit, archive))
@@ -411,20 +411,20 @@ class LeanProject:
         found_commit, archive = archives[0]
 
         if len(archives) > 1:
-            archive_items = ''.join([f'\n * {r.hexsha}' for r, ar in archives])
-            commit_args = ''.join([f' {r.hexsha}^!' for r, ar in archives])
+            archive_items = ''.join([f'\n * {short_sha(r)}' for r, ar in archives])
+            commit_args = ''.join([f' {short_sha(r)}^!' for r, ar in archives])
             log.warn(
-                f"No cache was available for {commit.hexsha}.\n"
+                f"No cache was available for {short_sha(commit)}.\n"
                 f"There are multiple viable caches from parent commits, using the first:{archive_items}\n"
                 f"All caches have been downloaded; use `get-cache --rev` to select a different one.\n"
                 f"To see the commits in question, run:\n"
-                f"  git log --graph {commit.hexsha}{commit_args}")
+                f"  git log --graph {short_sha(commit)}{commit_args}")
         elif found_commit != commit:
             log.warn(
-                f"No cache was available for {commit.hexsha}. "
-                f"Using the cache for the ancestor {found_commit.hexsha}.\n"
+                f"No cache was available for {short_sha(commit)}. "
+                f"Using the cache for the ancestor {short_sha(found_commit)}.\n"
                 f"To see the intermediate commits, run:\n"
-                f"  git log --graph {commit.hexsha} {found_commit.hexsha}^!")
+                f"  git log --graph {short_sha(commit)} {short_sha(found_commit)}^!")
 
         self.clean_mathlib()
         self.mathlib_folder.mkdir(parents=True, exist_ok=True)

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -31,12 +31,13 @@ def dummy_repo(tmp_path):
     L = repo.index.commit("L", parent_commits=(J,))
     return repo
 
+
 @pytest.mark.parametrize(['match', 'exp_found', 'exp_visited'], [
     ('L', 'L', ''),           # finding the root prunes everything else
-    ('BFG', 'FG', 'LJHIE'),   # B is pruned
+    ('BFG', 'GF', 'LJHIE'),   # B is pruned
     ('K', '', 'LJHGDIFCEBA'),  # no match, all iterated
 ])
-def test_foo(dummy_repo, match, exp_found, exp_visited):
+def test_visit_ancestors(dummy_repo, match, exp_found, exp_visited):
     assert dummy_repo.head.commit.message == 'L'
     found = []
     visited = []

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -20,6 +20,10 @@ def dummy_repo(tmp_path):
         cw.set_value("user", "name", "pytest")
         cw.set_value("user", "email", "<>")
 
+    # workaround for https://github.com/gitpython-developers/GitPython/pull/1314
+    import os
+    os.environ['USER'] = 'gitpython needs this to be here so it can ignore it'
+
     A = repo.index.commit("A")
     B = repo.index.commit("B", parent_commits=(A,))
     C = repo.index.commit("C", parent_commits=(B,))

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -1,0 +1,50 @@
+import pytest
+from types import SimpleNamespace
+import git
+from mathlibtools.git_helpers import visit_ancestors
+
+
+@pytest.fixture
+def dummy_repo(tmp_path):
+    r"""
+    A -- B -- E -- I -- J -- L
+          \       /    /
+           C --- F -- H
+            \        /
+             D ---- G --- K
+    """
+    d = tmp_path / "repo"
+    d.mkdir()
+    repo = git.Repo.init(d)
+
+    A = repo.index.commit("A")
+    B = repo.index.commit("B", parent_commits=(A,))
+    C = repo.index.commit("C", parent_commits=(B,))
+    D = repo.index.commit("D", parent_commits=(C,))
+    E = repo.index.commit("E", parent_commits=(B,))
+    F = repo.index.commit("F", parent_commits=(C,))
+    G = repo.index.commit("G", parent_commits=(D,))
+    I = repo.index.commit("I", parent_commits=(E, F))
+    H = repo.index.commit("H", parent_commits=(F, G))
+    J = repo.index.commit("J", parent_commits=(I, H))
+    K = repo.index.commit("K", parent_commits=(G,))
+    L = repo.index.commit("L", parent_commits=(J,))
+    return repo
+
+@pytest.mark.parametrize(['match', 'exp_found', 'exp_visited'], [
+    ('L', 'L', ''),           # finding the root prunes everything else
+    ('BFG', 'FG', 'LJHIE'),   # B is pruned
+    ('K', '', 'LJHGDIFCEBA'),  # no match, all iterated
+])
+def test_foo(dummy_repo, match, exp_found, exp_visited):
+    assert dummy_repo.head.commit.message == 'L'
+    found = []
+    visited = []
+    for c, prune in visit_ancestors(dummy_repo.head.commit):
+        if c.message in list(match):
+            prune()
+            found.append(c.message)
+        else:
+            visited.append(c.message)
+    assert visited == list(exp_visited)
+    assert found == list(exp_found)

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -16,6 +16,9 @@ def dummy_repo(tmp_path):
     d = tmp_path / "repo"
     d.mkdir()
     repo = git.Repo.init(d)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "pytest")
+        cw.set_value("user", "email", "<>")
 
     A = repo.index.commit("A")
     B = repo.index.commit("B", parent_commits=(A,))


### PR DESCRIPTION
Roughly implements what is described in [this zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/get-mathlib-at-commit/near/213010027).
This walks the commit graph, starting from the current commit and going via all parents, until all paths are "blocked" by a commit that has a cache available. The resulting set of caches are unordered with respect to the git graph; none are parents of the other, so all are equally suitable candidates based on the commit graph alone.

For now, we download all suitable caches but then pick one arbitrarily. By printing out all the caches we downloaded, the user can look at their history and make an educated guess at which one will be best for them; for instance by looking at which has a smaller diff with their current commit, or which touches more "foundational" files.

Tested by merging together two random PR branches, which gives the result:
```
$ py -3.8 -m mathlibtools.leanproject -f get-cache
Looking for remote mathlib oleans
Trying to download https://oleanstorage.azureedge.net/mathlib/cbacc5222625f3fb8fb9caa717009cafba045a2d.tar.xz to C:\Users\wiese\.mathlib\cbacc5222625f3fb8fb9caa717009cafba045a2d.tar.xz
No cache available for revision cbacc52226
Looking for remote mathlib oleans
Trying to download https://oleanstorage.azureedge.net/mathlib/dc6adcc85e0197075ea3a2e55c03e854008f5916.tar.xz to C:\Users\wiese\.mathlib\dc6adcc85e0197075ea3a2e55c03e854008f5916.tar.xz
100%|███████████████████████████████████████████████████████████████████| 44.8M/44.8M [00:10<00:00, 4.61MB/s] Found mathlib oleans at https://oleanstorage.azureedge.net/mathlib/
Looking for remote mathlib oleans
Trying to download https://oleanstorage.azureedge.net/mathlib/a2ff4126158907423495941eab9db0995c58a973.tar.xz to C:\Users\wiese\.mathlib\a2ff4126158907423495941eab9db0995c58a973.tar.xz
No cache available for revision a2ff412615
Looking for remote mathlib oleans
Trying to download https://oleanstorage.azureedge.net/mathlib/0323adaf907a25d4bbf67c106ccc520a30395f9f.tar.xz to C:\Users\wiese\.mathlib\0323adaf907a25d4bbf67c106ccc520a30395f9f.tar.xz
100%|███████████████████████████████████████████████████████████████████| 44.8M/44.8M [00:04<00:00, 9.61MB/s] Found mathlib oleans at https://oleanstorage.azureedge.net/mathlib/
No cache was available for cbacc52226.
There are multiple viable caches from parent commits, using the first:
 * dc6adcc85e
 * 0323adaf90
All caches have been downloaded; use `get-cache --rev` to select a different one.
To see the commits in question, run:
  git log --graph cbacc52226 dc6adcc85e^! 0323adaf90^!
```
```
$ git log --graph cbacc52226 dc6adcc85e^! 0323adaf90^!
*   commit cbacc5222625f3fb8fb9caa717009cafba045a2d (HEAD -> eric-wieser/kronecker)
|\  Merge: a2ff412615 dc6adcc85e
| | Author: Eric Wieser <wieser.eric@gmail.com>
| | Date:   Fri Aug 6 10:40:11 2021 +0100
| |
| |     Merge remote-tracking branch 'origin/master' into eric-wieser/kronecker
| |
| * commit dc6adcc85e0197075ea3a2e55c03e854008f5916 (origin/master, origin/HEAD)
|   Author: Yaël Dillies <yael.dillies@gmail.com>
|   Date:   Fri Aug 6 06:59:28 2021 +0000
|
|       feat(order/bounded_lattice): define the `distrib_lattice_bot` typeclass (#8507)
|
|       Typeclass for a distributive lattice with a least element.
|
|       This typeclass is used to generalize `disjoint_sup_left` and similar.
|
|       It inserts itself in the hierarchy between `semilattice_sup_bot, semilattice_inf_bot` and `generalized_boolean_algebra`, `bounded_distrib_lattice`. I am doing it through `extends`.
|
* commit a2ff4126158907423495941eab9db0995c58a973
| Author: Eric Wieser <wieser.eric@gmail.com>
| Date:   Fri Aug 6 10:33:35 2021 +0100
|
|     test
|
* commit 0323adaf907a25d4bbf67c106ccc520a30395f9f (origin/eric-wieser/kronecker)
  Author: faenuccio <filippo.nuccio@univ-st-etienne.fr>
  Date:   Fri Aug 6 11:09:54 2021 +0200

      modified docs
```

This also removes the retry logic, which shouldn't need to be special cased now that we use `atomicwrites` to never leave a partial cache. If we want it back, it probably belongs in `get_mathlib_archive`.

You can try this out with `python3 -m pipx install git+https://github.com/eric-wieser/mathlib-tools@get-cache-search`