### PR TITLE
fix(ci): Add missing dependency for PyInstaller

### DIFF
--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: 3.9
 
     - name: Install pyinstaller
-      run: python -m pip install pyinstaller -r mathlibtools/pyinstaller-requirements.txt
+      run: python -m pip install pyinstaller -r pyinstaller-requirements.txt
 
     - name: Run pyinstaller
       run: python -m PyInstaller mathlibtools/leanproject.spec

--- a/pyinstaller-requirements.txt
+++ b/pyinstaller-requirements.txt
@@ -1,4 +1,5 @@
 altgraph==0.17
+atomicwrites==1.4.0
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2


### PR DESCRIPTION
Merging #101 broke master, as the dependencies had changed since that PR was created.

This adds back the dependency, and moves the requirements.txt file to a more sensible place.