### PR TITLE
feat(get-cache): Show a vague indicator of progress when untar-ing the cache

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -110,7 +110,8 @@ def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
 def unpack_archive(fname: Union[str, Path], tgt_dir: Union[str, Path]) -> None:
     """ Alternative to `shutil.unpack_archive` that shows progress"""
     with tarfile.open(fname) as tarobj:
-        tarobj.extractall(str(tgt_dir), members=tqdm(tarobj))
+        tarobj.extractall(
+            str(tgt_dir), members=tqdm(tarobj, desc='  files extracted', unit=''))
 
 class OleanCache:
     """ A reference to a cache of oleans for a single commit.

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -14,6 +14,7 @@ import contextlib
 import enum
 from datetime import datetime
 import concurrent.futures
+import tarfile
 from typing import Iterable, IO, Union, List, Tuple, Optional, Dict, TYPE_CHECKING
 from tempfile import TemporaryDirectory
 import shutil
@@ -107,10 +108,9 @@ def pack(root: Path, srcs: Iterable[Path], target: Path) -> None:
     os.chdir(str(cur_dir))
 
 def unpack_archive(fname: Union[str, Path], tgt_dir: Union[str, Path]) -> None:
-    """Unpack archive. This is needed for python < 3.7."""
-    shutil.unpack_archive(str(fname), str(tgt_dir))
-
-
+    """ Alternative to `shutil.unpack_archive` that shows progress"""
+    with tarfile.open(fname) as tarobj:
+        tarobj.extractall(str(tgt_dir), members=tqdm(tarobj))
 
 class OleanCache:
     """ A reference to a cache of oleans for a single commit.


### PR DESCRIPTION
This at least prints out the number of files extracted so far, which clues the user into the fact that it is making progress.
For instance, on my machine this now shows:
```
Applying cache
  files extracted: 1651 [00:18, 90.61/s]
```
where the second line is new.
Instrumenting the extraction doesn't appear to impact performance in any meaningful way.

I tried to make it show a proper progress bar, but that requires knowing the contents of the tar file in advance.
It doesn't seem to be safe to iterate the members of a `tarfile.TarFile` from one thread and read them from another, so I didn't bother exploring further.