### PR TITLE
fix: various improvements to get-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.1.0dev (unreleased)
 
 * `get-mathlib-cache` no longer understands `--rev`; if you want to use a
-  different mathlib version, edit your `leanproject.toml`.
+  different mathlib version, edit your `leanproject.toml`. If you are trying to get
+  the cache when working on mathlib itself, use `get-cache`.
 * Add `--fallback` to `get-cache` for traversing the git history to find an
   approximate cache.
 * `get-cache` no longer modifies `lean` files in the working directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 1.1.0dev (unreleased)
+
+* `get-mathlib-cache` no longer understands `--rev`; if you want to use a
+  different mathlib version, edit your `leanproject.toml`.
+* Add `--fallback` to `get-cache` for traversing the git history to find an
+  approximate cache.
+* `get-cache` no longer modifies `lean` files in the working directory.
+* `mk-cache --force` no longer associates the cache with the current HEAD
+  revision, but instead creates a temporary commit in order to obtain a SHA1 id.
+
 ## 1.0.0 (2020-11-10)
 
 * Only look for .xz archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 * `get-mathlib-cache` no longer understands `--rev`; if you want to use a
   different mathlib version, edit your `leanproject.toml`. If you are trying to get
-  the cache when working on mathlib itself, use `get-cache`.
+  the cache when working on mathlib itself, use `get-cache --rev`.
 * Add `--fallback` to `get-cache` for traversing the git history to find an
   approximate cache.
-* `get-cache` no longer modifies `lean` files in the working directory.
+* `get-cache` no longer modifies `.lean` files in the working directory.
 * `mk-cache --force` no longer permits the working tree to be dirty.
-  revision, but instead creates a temporary commit in order to obtain a SHA1 id.
 
 ## 1.0.0 (2020-11-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add `--fallback` to `get-cache` for traversing the git history to find an
   approximate cache.
 * `get-cache` no longer modifies `lean` files in the working directory.
-* `mk-cache --force` no longer associates the cache with the current HEAD
+* `mk-cache --force` no longer permits the working tree to be dirty.
   revision, but instead creates a temporary commit in order to obtain a SHA1 id.
 
 ## 1.0.0 (2020-11-10)

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -214,7 +214,7 @@ def get_cache(rev: Optional[str], force: bool, fallback: str) -> None:
     """Restore cached olean files.
 
     \b
-    The fallback parameter is intepreted as follows:
+    The fallback parameter is interpreted as follows:
       none: fail without trying anything else
       show: show but do not download possible fallback caches
       download-first: show all fallback caches, download and apply the first
@@ -238,7 +238,7 @@ def get_mathlib_cache(rev: Optional[str], fallback: str) -> None:
     """Get mathlib .lean and .olean files, without upgrading.
 
     \b
-    The fallback parameter is intepreted as follows:
+    The fallback parameter is interpreted as follows:
       none: fail without trying anything else
       show: show but do not download possible fallback caches
       download-first: show all fallback caches, download and apply the first

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -237,7 +237,7 @@ def get_cache(rev: Optional[str], force: bool, fallback: str) -> None:
         handle_exception(err, 'Failed to fetch cached oleans')
 
 @cli.command()
-def get_mathlib_cache(rev: Optional[str], fallback: str) -> None:
+def get_mathlib_cache() -> None:
     """Get mathlib .lean and .olean files in a project depending on mathlib,
     without upgrading."""
     project = proj()

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -8,7 +8,7 @@ from git.exc import GitCommandError # type: ignore
 
 import click
 
-from mathlibtools.lib import (LeanProject, log, LeanDirtyRepo,
+from mathlibtools.lib import (LeanProject, log,
     InvalidLeanProject, LeanDownloadError, set_download_url, touch_oleans,
     CacheFallback)
 
@@ -218,11 +218,7 @@ def get_cache(rev: Optional[str], fallback: str) -> None:
     """
     fallback_enum = CacheFallback(fallback)
     try:
-        proj().get_cache(rev, force, fallback_enum)
-    except LeanDirtyRepo as err:
-        handle_exception(err,
-                'The repository is dirty, please commit changes before '
-                'fetching cache, or run this command with option --force.')
+        proj().get_cache(rev, fallback_enum)
     except (LeanDownloadError, FileNotFoundError) as err:
         handle_exception(err, 'Failed to fetch cached oleans')
 

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -194,30 +194,20 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
 
 @cli.command()
 @click.option('--force', default=False, is_flag=True,
-              help='Make cache even if the repository is dirty or cache exists.')
+              help='Make cache even if the cache already exists.')
 def mk_cache(force: bool = False) -> None:
     """Cache olean files.
 
-    If run with `--force` on a dirty repository, this creates a temporary commit
-    to associate the dirty cache with."""
-    try:
-        proj().mk_cache(force)
-    except LeanDirtyRepo as err:
-        handle_exception(err,
-                'The repository is dirty, please commit changes before '
-                'making cache, or run this command with option --force.')
+    The repository must be clean in order to ensure there is a suitable git
+    commit to associate the hash with."""
+    proj().mk_cache(force)
 
 @cli.command()
-@click.option('--force', default=False, is_flag=True,
-              help='Get cache even if the repository is dirty.')
 @click.option('--rev', default=None, help='A git sha.')
 @click.option('--fallback', type=click.Choice(['none', 'show', 'download-first', 'download-all']),
               default='show', help="Behavior if no matching cache is available.")
-def get_cache(rev: Optional[str], force: bool, fallback: str) -> None:
-    """Restore cached olean files.
-
-    This will refuse to run on a dirty repo by default, as doing so could blow
-    away olean files which would be time-consuming to reconstruct.
+def get_cache(rev: Optional[str], fallback: str) -> None:
+    """Restore olean files from a cache.
 
     \b
     The fallback parameter is interpreted as follows:

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -586,6 +586,8 @@ class LeanProject:
         """Cache oleans for this project."""
         if not self.rev:
             raise ValueError('This project has no git commit.')
+        if not self.repo:
+            raise LeanProjectError('This project has no git repository.')
         rev = self.rev
         if self.is_dirty:
             if force:

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -165,6 +165,7 @@ class RemoteOleanCache(OleanCache):
     This holds an open HTTP connection to the server from which the cache can be downloaded."""
     def __init__(self, locator: 'CacheLocator', rev):
         super().__init__(locator, rev)
+        assert self.locator.cache_url is not None
         self.req = requests.get(self.locator.cache_url + self.fname, stream=True)
         self.req.raise_for_status()
 

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -112,7 +112,7 @@ def unpack_archive(fname: Union[str, Path], tgt_dir: Union[str, Path],
     """ Alternative to `shutil.unpack_archive` that shows progress"""
     with tarfile.open(fname) as tarobj:
         if oleans_only:
-            members = (f for f in tarobj if Path(f.name).suffix == '.olean')
+            members : Iterable[tarfile.TarInfo] = (f for f in tarobj if Path(f.name).suffix == '.olean')
         else:
             members = tarobj
         tarobj.extractall(


### PR DESCRIPTION
Apologies for the size of this PR; my impression was that the semantics of some of the commands were mixed up, and it was easier to change them all at once

### Before this PR

* `leanproject mk-cache --force` on a dirty tree:
  * Creates a cache entry for `HEAD` that represents the dirty state of the working tree (which is not HEAD!)

* `leanproject get-cache`
  * on Mathlib:
    * Does a full history search
    * Unpacks the full archive over the working tree. If this archive comes from azure, it contains only oleans; if it comes from `mk-cache` it contains all the lean source files too.
  * on another project:
    * Uses only an exact match
    * Always overwrites local lean files, meaning that `get-cache --rev old_revision` acts much like `git checkout old_revision -- .`

* `leanproject get-mathlib-cache`
  * on mathlib:
    * Behaved identically to `leanproject get-cache`
  * on another project:
    * Does a full history search
    * Checks out lean files by running `git reset` on mathlib
 
### After this PR

* `leanproject mk-cache --force` on a dirty tree:
  * is not supported. `--force` is now only for overwriting the cache if it exists

* `leanproject get-cache` on any project:
  * Does a full history search
  * Unpacks only olean files
  * No longer supports `--force`. It only made sense in the presence of the destructive behavior regarding .lean files, which is no longer present.

* `leanproject get-mathlib-cache`
  * No longer supports `--rev` 
  * on mathlib:
    * Behaved identically to `leanproject get-cache`, spits out a warning telling the user to use `get-cache` directly.
  * on another project:
    * Does a full history search
    * Checks out mathlib lean files by running `git reset` on mathlib, then applying lean files from the tarball.
 
This replaces #96