### PR TITLE
wrap filenames containing hyphens in french quotes when making all.lean

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -846,7 +846,7 @@ class LeanProject:
 
         # helper function to wrap file paths in double quotes if they
         # contain dashes, so that lean accepts them as imports
-        def make_safe(s):
+        def escape_identifier(s : str) -> str:
             if re.match(LEAN_UNESCAPED_IDENTIFIER_RE, s):
                 return s
             return "«" + s + "»"

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -855,10 +855,10 @@ class LeanProject:
 
         with (self.src_directory/'all.lean').open('w') as all_file:
             for path in self.src_directory.glob('**/*.lean'):
-                rel = str(path.relative_to(self.src_directory).with_suffix(''))
-                if rel == 'all':
+                rel = path.relative_to(self.src_directory).with_suffix('')
+                if rel == Path('all'):
                     continue
-                all_file.write('import ' + ".".join(map(escape_identifier, rel.split(os.path.sep))) + '\n')
+                all_file.write('import ' + ".".join(map(escape_identifier, rel.parts)) + '\n')
 
     def list_decls(self) -> Dict[str, DeclInfo]:
         """Collect declarations seen from this project, as a dictionary of

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -70,7 +70,11 @@ DOWNLOAD_URL_FILE = DOT_MATHLIB/'url'
 
 MATHLIB_URL = 'https://github.com/leanprover-community/mathlib.git'
 LEAN_VERSION_RE = re.compile(r'(.*)\t.*refs/heads/lean-(.*)')
-LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*""")
+# This regex is from [1] and implements the logic at [2].
+# [1]: https://github.com/leanprover/vscode-lean/blob/2b43982c4c6305a0f20f156152a60613a6f1a683/syntaxes/lean.json#L193
+# [2]: https://github.com/leanprover-community/lean/blob/65ad4ffdb3abac75be748554e3cbe990fb1c6500/src/util/name.cpp#L65-L83
+LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(
+    r"(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*")
 
 VersionTuple = Tuple[int, int, int]
 

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -70,7 +70,7 @@ DOWNLOAD_URL_FILE = DOT_MATHLIB/'url'
 
 MATHLIB_URL = 'https://github.com/leanprover-community/mathlib.git'
 LEAN_VERSION_RE = re.compile(r'(.*)\t.*refs/heads/lean-(.*)')
-LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*(\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*)*""")
+LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*""")
 
 VersionTuple = Tuple[int, int, int]
 
@@ -115,9 +115,10 @@ def unpack_archive(fname: Union[str, Path], tgt_dir: Union[str, Path]) -> None:
             str(tgt_dir), members=tqdm(tarobj, desc='  files extracted', unit=''))
 
 def escape_identifier(s : str) -> str:
-    """ Helper function to wrap identifiers in double french quotes if they
-    need to be wrapped by lean, we use this for file paths so that lean accepts
-    them as imports"""
+    """ Helper function to wrap _pieces_ of identifiers in double french quotes
+    if they need to be wrapped by lean, we use this for file paths so we also escape
+    strings of the form `a.a` even though they are in valid identifiers.
+    By escaping strings we ensure that lean accepts them as imports"""
     if re.fullmatch(LEAN_UNESCAPED_IDENTIFIER_RE, s):
         return s
     return "«" + s + "»"

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -70,6 +70,7 @@ DOWNLOAD_URL_FILE = DOT_MATHLIB/'url'
 
 MATHLIB_URL = 'https://github.com/leanprover-community/mathlib.git'
 LEAN_VERSION_RE = re.compile(r'(.*)\t.*refs/heads/lean-(.*)')
+LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""^(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*(\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*)*$""")
 
 VersionTuple = Tuple[int, int, int]
 
@@ -846,9 +847,9 @@ class LeanProject:
         # helper function to wrap file paths in double quotes if they
         # contain dashes, so that lean accepts them as imports
         def make_safe(s):
-            if "-" in s:
-                return "«" + s + "»"
-            return s
+            if re.match(LEAN_UNESCAPED_IDENTIFIER_RE, s):
+                return s
+            return "«" + s + "»"
 
         with (self.src_directory/'all.lean').open('w') as all_file:
             for path in self.src_directory.glob('**/*.lean'):

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -842,12 +842,20 @@ class LeanProject:
 
     def make_all(self) -> None:
         """Creates all.lean importing everything from the project"""
+
+        # helper function to wrap file paths in double quotes if they
+        # contain dashes, so that lean accepts them as imports
+        def make_safe(s):
+            if "-" in s:
+                return "«" + s + "»"
+            return s
+
         with (self.src_directory/'all.lean').open('w') as all_file:
             for path in self.src_directory.glob('**/*.lean'):
                 rel = str(path.relative_to(self.src_directory).with_suffix(''))
                 if rel == 'all':
                     continue
-                all_file.write('import ' + rel.replace(os.path.sep, '.') + '\n')
+                all_file.write('import ' + ".".join(map(make_safe, rel.split(os.path.sep))) + '\n')
 
     def list_decls(self) -> Dict[str, DeclInfo]:
         """Collect declarations seen from this project, as a dictionary of

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -70,7 +70,7 @@ DOWNLOAD_URL_FILE = DOT_MATHLIB/'url'
 
 MATHLIB_URL = 'https://github.com/leanprover-community/mathlib.git'
 LEAN_VERSION_RE = re.compile(r'(.*)\t.*refs/heads/lean-(.*)')
-LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""^(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*(\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*)*$""")
+LEAN_UNESCAPED_IDENTIFIER_RE = re.compile(r"""(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*(\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟](?:(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])*)*""")
 
 VersionTuple = Tuple[int, int, int]
 
@@ -847,7 +847,7 @@ class LeanProject:
         # helper function to wrap file paths in double quotes if they
         # contain dashes, so that lean accepts them as imports
         def escape_identifier(s : str) -> str:
-            if re.match(LEAN_UNESCAPED_IDENTIFIER_RE, s):
+            if re.fullmatch(LEAN_UNESCAPED_IDENTIFIER_RE, s):
                 return s
             return "«" + s + "»"
 

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -121,7 +121,7 @@ def unpack_archive(fname: Union[str, Path], tgt_dir: Union[str, Path]) -> None:
 def escape_identifier(s : str) -> str:
     """ Helper function to wrap _pieces_ of identifiers in double french quotes
     if they need to be wrapped by lean, we use this for file paths so we also escape
-    strings of the form `a.a` even though they are in valid identifiers.
+    strings of the form `a.a` even though they are valid identifiers.
     By escaping strings we ensure that lean accepts them as imports"""
     if re.fullmatch(LEAN_UNESCAPED_IDENTIFIER_RE, s):
         return s


### PR DESCRIPTION
This caused problems for list_decls and other tools, as in https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Create.20a.20blueprint/near/251398961

Probably users should still not use hyphens in filenames.