### PR TITLE
feat(leanproject mk-cache --force): create a temporary commit to house dirty caches

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -196,7 +196,10 @@ def get_project(name: str, new_branch: bool, directory: str = '') -> None:
 @click.option('--force', default=False, is_flag=True,
               help='Make cache even if the repository is dirty or cache exists.')
 def mk_cache(force: bool = False) -> None:
-    """Cache olean files."""
+    """Cache olean files.
+
+    If run with `--force` on a dirty repository, this creates a temporary commit
+    to associate the dirty cache with."""
     try:
         proj().mk_cache(force)
     except LeanDirtyRepo as err:


### PR DESCRIPTION
The cache is indexed by the SHA1 of the working tree that produced it.
Previously `mk-cache --force` ignored this indexing scheme, replacing the cache for SHA1 with a non-matching cache.

The new behavior is to create a temporary commit containing the changes in the working tree, and associate the cache with that commit.
The commit is not created on the users current branch, so does not interfere with the user's use of git.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/What.20is.20.60leanproject.20mk-cache.20--force.60.20for/near/250270614)