### PR TITLE
feat(mathlibtools): expose mathlibtools.__version__

### DIFF
--- a/mathlibtools/__init__.py
+++ b/mathlibtools/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__

--- a/mathlibtools/_version.py
+++ b/mathlibtools/_version.py
@@ -1,0 +1,8 @@
+# Package versioning solution originally found here:
+# http://stackoverflow.com/q/458550
+
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module
+__version__ = '1.0.0'

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 import setuptools
+from os import path
 
-with open("README.md", "r") as fh:
+this_directory = path.abspath(path.dirname(__file__))
+
+with open(path.join(this_directory, "README.md"), encoding='utf-8') as fh:
     long_description = fh.read()
+
+with open(path.join(this_directory, 'mathlibtools', '_version.py'), encoding='utf-8') as f:
+    exec(f.read())
 
 setuptools.setup(
     name="mathlibtools",
-    version="1.0.0",
+    version=__version__,  # from _version.py
     author="The mathlib community",
     description="Lean prover mathlib supporting tools.",
     long_description=long_description,

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,0 +1,6 @@
+""" Tests API provided by `mathlibtools` to other Python scripts """
+import mathlibtools
+
+
+def test_version():
+	assert isinstance(mathlibtools.__version__, str)


### PR DESCRIPTION
This allows someone using the python part of the API to get the version number.

This also pre-emptively solves any problems that unicode characters in the readme would cause.