### PR TITLE
feat: --reduce flag to omit transitive imports

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -79,3 +79,9 @@ class ImportGraph(nx.DiGraph):
         H = self.subgraph([n for n in self.nodes if not str.startswith(n, ('tactic.', 'meta.'))])
         H.base_path = self.base_path
         return H
+
+    def transitive_reduction(self) -> 'ImportGraph':
+        """Removes all imports that are in the transitive closure of other imports."""
+        H = self.edge_subgraph(nx.transitive_reduction(self).edges())
+        H.base_path = self.base_path
+        return H

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -302,6 +302,8 @@ def global_upgrade() -> None:
               help='Color by mathlib4 porting status')
 @click.option('--port-status-url', default=None,
               help='URL of yaml with mathlib4 port status')
+@click.option('--reduce', 'reduce', default=False, is_flag=True,
+              help='Omit transitive imports.')
 @click.argument('output', default='import_graph.dot')
 def import_graph(
     to: Optional[str],
@@ -309,6 +311,7 @@ def import_graph(
     exclude : bool,
     port_status: bool,
     port_status_url: Optional[str],
+    reduce: bool,
     output: str
 ) -> None:
     """Write an import graph for this project.
@@ -335,6 +338,8 @@ def import_graph(
         G = graph.descendants(from_)
     else:
         G = graph
+    if reduce:
+        G = G.transitive_reduction()
     G.write(Path(output))
 
 


### PR DESCRIPTION
It may be sensible to add this as the default, as the transitive imports are nearly always just clutter.