### PR TITLE
chore: fix port-status colour

### DIFF
--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -298,6 +298,8 @@ def global_upgrade() -> None:
               help='Return only imports starting from this file.')
 @click.option('--exclude-tactics', 'exclude', default=False, is_flag=True,
               help='Excludes tactics and meta.')
+@click.option('--include-deps', 'include_deps', default=False, is_flag=True,
+              help='Include imports from outside the project.')
 @click.option('--port-status', default=False, is_flag=True,
               help='Color by mathlib4 porting status')
 @click.option('--port-status-url', default=None,
@@ -309,6 +311,7 @@ def import_graph(
     to: Optional[str],
     from_: Optional[str],
     exclude : bool,
+    include_deps : bool,
     port_status: bool,
     port_status_url: Optional[str],
     reduce: bool,
@@ -324,6 +327,11 @@ def import_graph(
     For .dot, .pdf, .svg, or .png output you will need to install 'graphviz' first.
     """
     project = proj()
+
+    if include_deps:
+        project.graph_include_deps = include_deps
+        project.graph_exclude_tactics = exclude
+
     graph = project.import_graph
     if exclude:
         graph = graph.exclude_tactics()

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -860,7 +860,11 @@ class LeanProject:
         for path in self.src_directory.glob('**/*.lean'):
             rel = path.relative_to(self.src_directory)
             label = str(rel.with_suffix('')).replace(os.sep, '.')
-            G.add_node(label)
+            if self.graph_include_deps:
+                # Colouring project gold to make it visible among deps.
+                G.add_node(label, style='filled', fillcolor='gold1')
+            else:
+                G.add_node(label)
             imports = self.run(['lean', '--deps', str(path)])
             for imp in map(Path, imports.split()):
                 try:
@@ -868,7 +872,7 @@ class LeanProject:
                 except ValueError:
                     # This import is not from the project
                     if self.graph_include_deps:
-                        if skip_dep(path):
+                        if skip_dep(imp):
                             continue
                         dependent_imps.add(imp.with_suffix('.lean'))
                         imp_label = str(imp.with_suffix('')).replace(os.sep, '.').split('src.')[-1]
@@ -901,7 +905,7 @@ class LeanProject:
                 traverse_deps(path)
 
             for node in dep_nodes:
-                G.add_node(node, color='silver')
+                G.add_node(node, color='lightslategrey')
             for edge in dep_edges:
                 G.add_edge(*edge)
 

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -1044,9 +1044,11 @@ class LeanProject:
                 # we don't need to redo a finished node
                 if target in finished_nodes:
                     continue
+                target_node = self.import_graph.nodes[target]
+                if target_node.get("status"):
+                    continue
                 parents = {parent for parent, _ in self.import_graph.in_edges(target)}
                 if parents.issubset(finished_nodes):
-                    target_node = self.import_graph.nodes[target]
                     target_node["status"] = FileStatus.ready()
         # now to get root nodes
         for target, degree in self.import_graph.in_degree():


### PR DESCRIPTION
As discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/some.20useful.20automation/near/307016762).
`import_graph --port-status` currently ignores the [port status file](https://github.com/leanprover-community/mathlib/wiki/mathlib4-port-status/)  if all dependencies are ported. E.g. it shows `algebra.ne_zero` as "ready to port" instead of "PR exists".