### PR TITLE
chore(import-graph): don't overwrite 'PR' colour with 'ready' colour

### DIFF
--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -1047,7 +1047,8 @@ class LeanProject:
                 parents = {parent for parent, _ in self.import_graph.in_edges(target)}
                 if parents.issubset(finished_nodes):
                     target_node = self.import_graph.nodes[target]
-                    target_node["status"] = FileStatus.ready()
+                    if target_node["status"] not in [FileStatus.wip(), FileStatus.pr()]:
+                        target_node["status"] = FileStatus.ready()
         # now to get root nodes
         for target, degree in self.import_graph.in_degree():
             target_node = self.import_graph.nodes[target]

--- a/mathlibtools/lib.py
+++ b/mathlibtools/lib.py
@@ -1047,7 +1047,7 @@ class LeanProject:
                 parents = {parent for parent, _ in self.import_graph.in_edges(target)}
                 if parents.issubset(finished_nodes):
                     target_node = self.import_graph.nodes[target]
-                    if target_node["status"] not in [FileStatus.wip(), FileStatus.pr()]:
+                    if not target_node.get("status"):
                         target_node["status"] = FileStatus.ready()
         # now to get root nodes
         for target, degree in self.import_graph.in_degree():


### PR DESCRIPTION
The colours scheme in `import-graph` makes more sense if the "PR" status takes precedence of the "ready" colour.