### PR TITLE
feat: add transitive edges when removing tactics nodes from the import-graph

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -75,8 +75,17 @@ class ImportGraph(nx.DiGraph):
         return H
 
     def exclude_tactics(self) -> 'ImportGraph':
-        """Removes all files in src/tactic/ and src/meta/ from the graph."""
-        H = self.subgraph([n for n in self.nodes if not str.startswith(n, ('tactic.', 'meta.'))])
+        """Removes all files in src/tactic/ and src/meta/ from the graph (but adds extra edges to reflect transitive dependencies)."""
+        H = self
+        to_delete = [n for n in H.nodes if str.startswith(n, ('tactic.', 'meta.'))]
+        for n in to_delete:
+            if str.startswith(n, ('tactic.', 'meta.')):
+                parents = [k for (k, _) in H.in_edges([n])]
+                children = [m for (_, m) in H.out_edges([n])]
+                for k in parents:
+                    for m in children:
+                        H.add_edge(k, m)
+                H.remove_node(n)
         H.base_path = self.base_path
         return H
 

--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -75,17 +75,17 @@ class ImportGraph(nx.DiGraph):
         return H
 
     def exclude_tactics(self) -> 'ImportGraph':
-        """Removes all files in src/tactic/ and src/meta/ from the graph (but adds extra edges to reflect transitive dependencies)."""
+        """Removes all files in src/tactic/ and src/meta/ from the graph,
+        except src/tactic/basic.lean (but adds extra edges to reflect transitive dependencies)."""
         H = self
-        to_delete = [n for n in H.nodes if str.startswith(n, ('tactic.', 'meta.'))]
+        to_delete = [n for n in H.nodes if n != 'tactic.basic' and str.startswith(n, ('tactic.', 'meta.'))]
         for n in to_delete:
-            if str.startswith(n, ('tactic.', 'meta.')):
-                parents = [k for (k, _) in H.in_edges([n])]
-                children = [m for (_, m) in H.out_edges([n])]
-                for k in parents:
-                    for m in children:
-                        H.add_edge(k, m)
-                H.remove_node(n)
+            parents = [k for (k, _) in H.in_edges([n])]
+            children = [m for (_, m) in H.out_edges([n])]
+            for k in parents:
+                for m in children:
+                    H.add_edge(k, m)
+            H.remove_node(n)
         H.base_path = self.base_path
         return H
 

--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -76,9 +76,10 @@ class ImportGraph(nx.DiGraph):
 
     def exclude_tactics(self) -> 'ImportGraph':
         """Removes all files in src/tactic/ and src/meta/ from the graph,
-        except src/tactic/basic.lean (but adds extra edges to reflect transitive dependencies)."""
+        except tactic.basic and tactic.core (but adds extra edges to reflect transitive dependencies)."""
         H = self
-        to_delete = [n for n in H.nodes if n != 'tactic.basic' and str.startswith(n, ('tactic.', 'meta.'))]
+        to_delete = [n for n in H.nodes if
+            n != 'tactic.basic' and n != 'tactic.core' and str.startswith(n, ('tactic.', 'meta.'))]
         for n in to_delete:
             parents = [k for (k, _) in H.in_edges([n])]
             children = [m for (_, m) in H.out_edges([n])]

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -297,7 +297,7 @@ def global_upgrade() -> None:
 @click.option('--from', 'from_', default=None,
               help='Return only imports starting from this file.')
 @click.option('--exclude-tactics', 'exclude', default=False, is_flag=True,
-              help='Excludes tactics and meta.')
+              help='Excludes tactics and meta, adding edges for transitive dependencies.')
 @click.option('--port-status', default=False, is_flag=True,
               help='Color by mathlib4 porting status')
 @click.option('--port-status-url', default=None,
@@ -338,7 +338,7 @@ def import_graph(
         G = graph.descendants(from_)
     else:
         G = graph
-    if reduce:
+    if reduce or exclude:
         G = G.transitive_reduction()
     G.write(Path(output))
 

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -297,7 +297,7 @@ def global_upgrade() -> None:
 @click.option('--from', 'from_', default=None,
               help='Return only imports starting from this file.')
 @click.option('--exclude-tactics', 'exclude', default=False, is_flag=True,
-              help='Excludes tactics and meta besides tactic.basic, adding edges for transitive dependencies.')
+              help='Excludes tactics and meta, adding edges for transitive dependencies.')
 @click.option('--port-status', default=False, is_flag=True,
               help='Color by mathlib4 porting status')
 @click.option('--port-status-url', default=None,

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -297,7 +297,7 @@ def global_upgrade() -> None:
 @click.option('--from', 'from_', default=None,
               help='Return only imports starting from this file.')
 @click.option('--exclude-tactics', 'exclude', default=False, is_flag=True,
-              help='Excludes tactics and meta, adding edges for transitive dependencies.')
+              help='Excludes tactics and meta besides tactic.basic, adding edges for transitive dependencies.')
 @click.option('--port-status', default=False, is_flag=True,
               help='Color by mathlib4 porting status')
 @click.option('--port-status-url', default=None,


### PR DESCRIPTION
Previously if you used `--exclude-tactics` any imports that were only imported via transitive dependencies through tactics files would be silently dropped.