### PR TITLE
Support yaml-style port status files

### DIFF
--- a/mathlibtools/file_status.py
+++ b/mathlibtools/file_status.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Mapping, Optional, Union
 
 import requests
 import yaml
@@ -32,7 +32,13 @@ class FileStatus:
         )
 
     def asdict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
+        return {k: v for k, v in asdict(self).items() if v is not None and v}
+
+    @classmethod
+    def fromdict(cls, indict: Optional[Mapping[str, Union[bool, int, str, None]]]) -> "FileStatus":
+        if indict is None:
+            indict = {}
+        return cls(**indict)
 
 
 
@@ -51,10 +57,30 @@ class PortStatus:
         return yaml_md_load(requests.get(url).content)
 
     @classmethod
+    def new_yaml(cls, url: Optional[str] = None) -> Dict[str, str]:
+        if url is None:
+            url = "https://raw.githubusercontent.com/wiki/leanprover-community/mathlib/mathlib4-port-status-new.md"
+        def yaml_md_load(wikicontent: bytes):
+            return yaml.safe_load(wikicontent.replace(b"```", b""))
+
+        return yaml_md_load(requests.get(url).content)
+
+    @classmethod
     def deserialize_old(cls, yaml: Optional[Dict[str, str]] = None) -> "PortStatus":
         if yaml is None:
             yaml = cls.old_yaml()
         return cls(file_statuses={k: FileStatus.parse_old(v) for k, v in yaml.items()})
 
     def serialize(self) -> Dict[str, Dict[str, Union[int, str, None]]]:
-        return yaml.dump({k: v.asdict() for k, v in self.file_statuses.items()})
+        # https://stackoverflow.com/a/37445121
+        yaml.SafeDumper.add_representer(
+            type(None),
+            lambda dumper, value: dumper.represent_scalar(u'tag:yaml.org,2002:null', '')
+        )
+        return yaml.safe_dump({k: v.asdict() if v.asdict() else None for k, v in self.file_statuses.items()})
+
+    @classmethod
+    def deserialize(cls, yaml: Optional[Dict[str, Any]] = None) -> "PortStatus":
+        if yaml is None:
+            yaml = cls.new_yaml()
+        return cls(file_statuses={k: FileStatus.fromdict(v) for k, v in yaml.items()})

--- a/mathlibtools/file_status.py
+++ b/mathlibtools/file_status.py
@@ -38,7 +38,7 @@ class FileStatus:
     def fromdict(cls, indict: Optional[Mapping[str, Union[bool, int, str, None]]]) -> "FileStatus":
         if indict is None:
             indict = {}
-        return cls(**indict)
+        return cls(**indict)  # type: ignore
 
 
 
@@ -83,4 +83,4 @@ class PortStatus:
     def deserialize(cls, yaml: Optional[Dict[str, Any]] = None) -> "PortStatus":
         if yaml is None:
             yaml = cls.new_yaml()
-        return cls(file_statuses={k: FileStatus.fromdict(v) for k, v in yaml.items()})
+        return cls(file_statuses={k: FileStatus.fromdict(v) for k, v in yaml.items()})  # type: ignore


### PR DESCRIPTION
Includes link to staging file of new style (https://raw.githubusercontent.com/wiki/leanprover-community/mathlib/mathlib4-port-status-new.md)