### PR TITLE
feat: add --exclude-ported flag for import-graph

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -105,6 +105,22 @@ class ImportGraph(nx.DiGraph):
         H.base_path = self.base_path
         return H
 
+    def delete_ported_children(self, exclude_tactics: bool) -> 'ImportGraph':
+        """Delete all nodes marked as ported during port_status"""
+        if exclude_tactics:
+            to_remove = {n for n in self.nodes if str.startswith(n, ('tactic.', 'meta.'))}
+        else:
+            to_remove = set()
+        finished_nodes = {node for node, attrs in self.nodes(data=True)
+                          if attrs.get("status").ported}
+        for node in finished_nodes:
+            children = {child for _, child in self.out_edges(node)}
+            if children.issubset(finished_nodes):
+                to_remove.add(node)
+        H = self.subgraph(self.nodes - to_remove)
+        H.base_path = self.base_path
+        return H
+
     def size(self) -> 'int':
         return nx.number_of_nodes(self)
 


### PR DESCRIPTION
See e.g. https://tqft.net/mathlib4/2022-12-09/data.rat.order.pdf for output. Excludes anything that has been ported, and whose children have been ported.

It seems a nice balance of showing context, but discarding old news.