### PR TITLE
feat: keep `to`-node in graph if it is ported

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -109,7 +109,7 @@ class ImportGraph(nx.DiGraph):
         return H
 
     def delete_ported(self, to:str='') -> 'ImportGraph':
-        """Delete all nodes (except target node 'to') marked as ported during port_status."""
+        """Delete all (children) nodes marked as ported during port_status."""
         H = self.subgraph({node for node, attrs in self.nodes(data=True)
                           if node == to or
                             not (attrs.get("status") and attrs.get("status").ported)})
@@ -117,7 +117,7 @@ class ImportGraph(nx.DiGraph):
         return H
 
     def delete_ported_children(self, exclude_tactics: bool, to:str='') -> 'ImportGraph':
-        """Delete all nodes (except target node 'to') marked as ported during port_status."""
+        """Delete children nodes marked as ported during port_status that are only imported by ported nodes."""
         if exclude_tactics:
             to_remove = {n for n in self.nodes if str.startswith(n, ('tactic.', 'meta.'))}
         else:

--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -117,7 +117,7 @@ class ImportGraph(nx.DiGraph):
         return H
 
     def delete_ported_children(self, exclude_tactics: bool, to:str='') -> 'ImportGraph':
-        """Delete children nodes marked as ported during port_status that are only imported by ported nodes."""
+        """Delete all nodes marked as ported during port_status"""
         if exclude_tactics:
             to_remove = {n for n in self.nodes if str.startswith(n, ('tactic.', 'meta.'))}
         else:

--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -108,15 +108,16 @@ class ImportGraph(nx.DiGraph):
         H.base_path = self.base_path
         return H
 
-    def delete_ported(self) -> 'ImportGraph':
-        """Delete all nodes marked as ported during port_status"""
+    def delete_ported(self, to:str='') -> 'ImportGraph':
+        """Delete all nodes (except target node 'to') marked as ported during port_status."""
         H = self.subgraph({node for node, attrs in self.nodes(data=True)
-                          if not (attrs.get("status") and attrs.get("status").ported)})
+                          if node == to or
+                            not (attrs.get("status") and attrs.get("status").ported)})
         H.base_path = self.base_path
         return H
 
-    def delete_ported_children(self, exclude_tactics: bool) -> 'ImportGraph':
-        """Delete all nodes marked as ported during port_status"""
+    def delete_ported_children(self, exclude_tactics: bool, to:str='') -> 'ImportGraph':
+        """Delete all nodes (except target node 'to') marked as ported during port_status."""
         if exclude_tactics:
             to_remove = {n for n in self.nodes if str.startswith(n, ('tactic.', 'meta.'))}
         else:
@@ -127,7 +128,7 @@ class ImportGraph(nx.DiGraph):
             children = {child for _, child in self.out_edges(node)}
             if children.issubset(finished_nodes):
                 to_remove.add(node)
-        H = self.subgraph(self.nodes - to_remove)
+        H = self.subgraph(self.nodes - to_remove.difference([to]))
         H.base_path = self.base_path
         return H
 

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -355,12 +355,12 @@ def import_graph(
     if reduce or exclude_tactics or exclude_ported:
         G = G.transitive_reduction()
     if exclude_ported:
-        G = G.delete_ported_children(exclude_tactics)
+        G = G.delete_ported_children(exclude_tactics, to=to)
         if to:
             # discard stray fragments from before the ported files
             G = G.ancestors(to)
     if really_exclude_ported:
-        G = G.delete_ported()
+        G = G.delete_ported(to=to)
         if to:
             # discard stray fragments from before the ported files
             G = G.ancestors(to)
@@ -382,7 +382,7 @@ def port_progress(to: Optional[str]) -> None:
     nb_files = graph.size()
     nb_lines = sum(node.get("nb_lines", 0) for name, node in graph.nodes(data=True))
     mathlib3_longest_path = graph.longest_path_length()
-    graph = graph.delete_ported()
+    graph = graph.delete_ported(to=to)
     nb_ported_files = nb_files - graph.size()
     proportion_files = round(nb_ported_files/nb_files*100, 1)
     nb_ported_lines = nb_lines - sum(node.get("nb_lines", 0) for name, node in graph.nodes(data=True))


### PR DESCRIPTION
With this small suggestion calling `import-graph --to $f --port-status --exclude-ported graph.pdf` (and `--really-exclude-ported`) on an already ported file `$f` will create a graph with a single green node instead of not creating any graph at all.