### PR TITLE
feat: --port-complete flag to list completely ported files

### DIFF
--- a/mathlibtools/import_graph.py
+++ b/mathlibtools/import_graph.py
@@ -131,6 +131,19 @@ class ImportGraph(nx.DiGraph):
         H.base_path = self.base_path
         return H
 
+    def completely_ported(self) -> 'ImportGraph':
+        """Retain only nodes marked as ported, and all of whose descendants are marked as ported."""
+        unported = {node for node, attrs in self.nodes(data=True)
+                    if not (attrs.get("status") and attrs.get("status").ported)}
+        unported.discard("all")
+        keeping = set(self.nodes)
+        keeping.discard("all")
+        for n in unported:
+            keeping = keeping.difference(nx.ancestors(self, n))
+            keeping.discard(n)
+        H = self.subgraph(keeping)
+        return H
+
     def size(self) -> 'int':
         return nx.number_of_nodes(self)
 

--- a/mathlibtools/leanproject.py
+++ b/mathlibtools/leanproject.py
@@ -421,6 +421,18 @@ def port_progress(to: Optional[str]) -> None:
         else:
             print("- " + n)
 
+@cli.command()
+def port_complete() -> None:
+    """List all files which have been ported to mathlib4,
+    and all downstream dependencies have been ported."""
+    project = proj()
+    project.port_status()
+    graph = project.import_graph
+    graph = graph.exclude_tactics()
+    graph = graph.transitive_reduction()
+    R = graph.completely_ported()
+    for n in sorted([n for n in R.nodes]):
+        print(n)
 
 @cli.command()
 @click.option('--sed', 'sed', default=False, is_flag=True,


### PR DESCRIPTION
Explained at [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/leanproject.20--port-complete).